### PR TITLE
Enable alleyPriority for automobile routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Various properties of `Route`, `RouteLeg`, and `RouteStep` are now writable. ([#393](https://github.com/mapbox/mapbox-directions-swift/pull/393))
 * Added `AttributeOptions.maximumSpeedLimit` for getting maximum posted speed limits in the `RouteLeg.segmentMaximumSpeedLimits` property. ([#367](https://github.com/mapbox/mapbox-directions-swift/pull/367))
 * Added the `RouteLeg.segmentRangesByStep` property for more easily associating `RouteStep`s with the values in segment-based arrays such as `RouteLeg.segmentCongestionLevels`. ([#367](https://github.com/mapbox/mapbox-directions-swift/pull/367))
+* The `RouteOptions.alleyPriority` property now works with `DirectionsProfileIdentifier.automobile`, allowing you to request routes that prefer or avoid alleys while driving. ([#416](https://github.com/mapbox/mapbox-directions-swift/pull/416))
 
 ## v0.30.0
 

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -110,7 +110,7 @@ open class RouteOptions: DirectionsOptions {
     /**
      A number that influences whether the route should prefer or avoid alleys or narrow service roads between buildings.
      
-     This property has no effect unless the profile identifier is set to `DirectionsProfileIdentifier.walking`.
+     This property has no effect unless the profile identifier is set to `DirectionsProfileIdentifier.automobile` or `DirectionsProfileIdentifier.walking`.
      
      The value of this property must be at least `DirectionsPriority.low` and at most `DirectionsPriority.high`. The default value of `DirectionsPriority.default` neither prefers nor avoids alleys, while a negative value between `DirectionsPriority.low` and `DirectionsPriority.default` avoids alleys, and a positive value between `DirectionsPriority.default` and `DirectionsPriority.high` prefers alleys. A value of 0.9 is suitable for pedestrians who are comfortable with walking down alleys.
      */
@@ -169,8 +169,10 @@ open class RouteOptions: DirectionsOptions {
             params.append(URLQueryItem(name: "roundabout_exits", value: String(includesExitRoundaboutManeuver)))
         }
 
-        if profileIdentifier == .walking {
+        if profileIdentifier == .automobile || profileIdentifier == .walking {
             params.append(URLQueryItem(name: "alley_bias", value: String(alleyPriority.rawValue)))
+        }
+        if profileIdentifier == .walking {
             params.append(URLQueryItem(name: "walkway_bias", value: String(walkwayPriority.rawValue)))
             params.append(URLQueryItem(name: "walking_speed", value: String(speed)))
         }

--- a/Tests/MapboxDirectionsTests/DirectionsTests.swift
+++ b/Tests/MapboxDirectionsTests/DirectionsTests.swift
@@ -42,7 +42,7 @@ class DirectionsTests: XCTestCase {
         XCTAssertEqual(directions.apiEndpoint.absoluteString, "https://api.mapbox.com")
     }
     
-    let maximumCoordinateCount = 795
+    let maximumCoordinateCount = 794
     
     func testGETRequest() {
         // Bumps right up against MaximumURLLength
@@ -54,7 +54,7 @@ class DirectionsTests: XCTestCase {
         XCTAssertLessThanOrEqual(url.absoluteString.count, MaximumURLLength, "maximumCoordinateCount is too high")
         
         let components = URLComponents(string: url.absoluteString)
-        XCTAssertEqual(components?.queryItems?.count, 7)
+        XCTAssertEqual(components?.queryItems?.count, 8)
         XCTAssertTrue(components?.path.contains(coordinates.compactMap { $0.requestDescription }.joined(separator: ";")) ?? false)
         
         let request = directions.urlRequest(forCalculating: options)
@@ -74,7 +74,7 @@ class DirectionsTests: XCTestCase {
         XCTAssertNotNil(request.httpBody)
         var components = URLComponents()
         components.query = String(data: request.httpBody ?? Data(), encoding: .utf8)
-        XCTAssertEqual(components.queryItems?.count, 7)
+        XCTAssertEqual(components.queryItems?.count, 8)
         XCTAssertEqual(components.queryItems?.first { $0.name == "coordinates" }?.value,
                        coordinates.compactMap { $0.requestDescription }.joined(separator: ";"))
     }


### PR DESCRIPTION
The `RouteOptions.alleyPriority` property now works with `DirectionsProfileIdentifier.automobile` in addition to `DirectionsProfileIdentifier.walking`.

/cc @mapbox/navigation-ios @avi-c