### PR TITLE
Use Result for directions response

### DIFF
--- a/Directions Example/ViewController.swift
+++ b/Directions Example/ViewController.swift
@@ -70,45 +70,49 @@ class ViewController: UIViewController, MBDrawingViewDelegate {
         options.routeShapeResolution = .full
         options.attributeOptions = [.congestionLevel, .maximumSpeedLimit]
         
-        Directions.shared.calculate(options) { (response, error) in
-            if let error = error {
+        Directions.shared.calculate(options) { (session, result) in
+            
+            switch (result) {
+            case let .failure(error):
                 print("Error calculating directions: \(error)")
                 return
-            }
-            
-            if let route = response.routes?.first, let leg = route.legs.first {
-                print("Route via \(leg):")
-                
-                let distanceFormatter = LengthFormatter()
-                let formattedDistance = distanceFormatter.string(fromMeters: route.distance)
-                
-                let travelTimeFormatter = DateComponentsFormatter()
-                travelTimeFormatter.unitsStyle = .short
-                let formattedTravelTime = travelTimeFormatter.string(from: route.expectedTravelTime)
-                
-                print("Distance: \(formattedDistance); ETA: \(formattedTravelTime!)")
-                
-                for step in leg.steps {
-                    let direction = step.maneuverDirection?.rawValue ?? "none"
-                    print("\(step.instructions) [\(step.maneuverType) \(direction)]")
-                    if step.distance > 0 {
-                        let formattedDistance = distanceFormatter.string(fromMeters: step.distance)
-                        print("— \(step.transportType) for \(formattedDistance) —")
+            case let .success(response):
+                if let route = response.routes?.first, let leg = route.legs.first {
+                    print("Route via \(leg):")
+                    
+                    let distanceFormatter = LengthFormatter()
+                    let formattedDistance = distanceFormatter.string(fromMeters: route.distance)
+                    
+                    let travelTimeFormatter = DateComponentsFormatter()
+                    travelTimeFormatter.unitsStyle = .short
+                    let formattedTravelTime = travelTimeFormatter.string(from: route.expectedTravelTime)
+                    
+                    print("Distance: \(formattedDistance); ETA: \(formattedTravelTime!)")
+                    
+                    for step in leg.steps {
+                        let direction = step.maneuverDirection?.rawValue ?? "none"
+                        print("\(step.instructions) [\(step.maneuverType) \(direction)]")
+                        if step.distance > 0 {
+                            let formattedDistance = distanceFormatter.string(fromMeters: step.distance)
+                            print("— \(step.transportType) for \(formattedDistance) —")
+                        }
+                    }
+                    
+                    if var routeCoordinates = route.shape?.coordinates, routeCoordinates.count > 0 {
+                        // Convert the route’s coordinates into a polyline.
+                        let routeLine = MGLPolyline(coordinates: &routeCoordinates, count: UInt(routeCoordinates.count))
+
+                        // Add the polyline to the map.
+                        self.mapView.addAnnotation(routeLine)
+                        
+                        // Fit the viewport to the polyline.
+                        let camera = self.mapView.cameraThatFitsShape(routeLine, direction: 0, edgePadding: .zero)
+                        self.mapView.setCamera(camera, animated: true)
                     }
                 }
-                
-                if var routeCoordinates = route.shape?.coordinates, routeCoordinates.count > 0 {
-                    // Convert the route’s coordinates into a polyline.
-                    let routeLine = MGLPolyline(coordinates: &routeCoordinates, count: UInt(routeCoordinates.count))
-
-                    // Add the polyline to the map.
-                    self.mapView.addAnnotation(routeLine)
-                    
-                    // Fit the viewport to the polyline.
-                    let camera = self.mapView.cameraThatFitsShape(routeLine, direction: 0, edgePadding: .zero)
-                    self.mapView.setCamera(camera, animated: true)
-                }
             }
+            
+            
         }
     }
     
@@ -144,8 +148,10 @@ class ViewController: UIViewController, MBDrawingViewDelegate {
     func makeMatchRequest(locations: [CLLocationCoordinate2D]) {
         let matchOptions = MatchOptions(coordinates: locations)
 
-        Directions.shared.calculate(matchOptions) { (response, error) in
-            if let error = error {
+        Directions.shared.calculate(matchOptions) { (session, result) in
+            
+            switch result {
+            case let .failure(error):
                 let errorString = """
                 ⚠️ Error Enountered. ⚠️
                 Failure Reason: \(error.failureReason ?? "")
@@ -155,19 +161,19 @@ class ViewController: UIViewController, MBDrawingViewDelegate {
                 """
                 print(errorString)
                 return
+            case let .success(response):
+                guard let matches = response.matches, let match = matches.first else { return }
+                if let annotations = self.mapView.annotations {
+                    self.mapView.removeAnnotations(annotations)
+                }
+                
+                var routeCoordinates = match.shape!.coordinates
+                let coordCount = UInt(routeCoordinates.count)
+                let routeLine = MGLPolyline(coordinates: &routeCoordinates, count: coordCount)
+                self.mapView.addAnnotation(routeLine)
+                self.drawingView?.reset()
             }
-            
-            guard let matches = response.matches, let match = matches.first else { return }
-            
-            if let annotations = self.mapView.annotations {
-                self.mapView.removeAnnotations(annotations)
-            }
-            
-            var routeCoordinates = match.shape!.coordinates
-            let coordCount = UInt(routeCoordinates.count)
-            let routeLine = MGLPolyline(coordinates: &routeCoordinates, count: coordCount)
-            self.mapView.addAnnotation(routeLine)
-            self.drawingView?.reset()
+
         }
     }
 }

--- a/Sources/MapboxDirections/Directions.swift
+++ b/Sources/MapboxDirections/Directions.swift
@@ -60,7 +60,7 @@ open class Directions: NSObject {
     
     public typealias MapMatchingError = (response: MapMatchingResponse, error: DirectionsError)
     
-    public typealias DirectionsSession = (options: DirectionsOptions, credentials: DirectionsCredentials)
+    public typealias Session = (options: DirectionsOptions, credentials: DirectionsCredentials)
     
     /**
      A closure (block) to be called when a directions request is complete.
@@ -69,7 +69,7 @@ open class Directions: NSObject {
      
      - parameter error: The error that occurred, or `nil` if the solution was obtained successfully.
      */
-    public typealias RouteCompletionHandler = (_ session: DirectionsSession, _ result: Result<RouteResponse, DirectionsError>) -> Void
+    public typealias RouteCompletionHandler = (_ session: Session, _ result: Result<RouteResponse, DirectionsError>) -> Void
     
     /**
      A closure (block) to be called when a map matching request is complete.
@@ -78,7 +78,7 @@ open class Directions: NSObject {
 
      - parameter error: The error that occurred, or `nil` if the solution was obtained successfully.
      */
-    public typealias MatchCompletionHandler = (_ session: DirectionsSession, _ result: Result<MapMatchingResponse, DirectionsError>) -> Void
+    public typealias MatchCompletionHandler = (_ session: Session, _ result: Result<MapMatchingResponse, DirectionsError>) -> Void
     
     // MARK: Creating a Directions Object
     

--- a/Sources/MapboxDirections/Directions.swift
+++ b/Sources/MapboxDirections/Directions.swift
@@ -60,9 +60,6 @@ open class Directions: NSObject {
     
     public typealias MapMatchingError = (response: MapMatchingResponse, error: DirectionsError)
     
-//    public typealias RouteError: Error = (result: RouteResponse, error: DirectionsError)
-//    public typealias MapMatchingError: Error = (result: MapMatchingResponse, error: DirectionsError)
-    
     public typealias DirectionsSession = (options: DirectionsOptions, credentials: DirectionsCredentials)
     
     /**

--- a/Sources/MapboxDirections/Directions.swift
+++ b/Sources/MapboxDirections/Directions.swift
@@ -122,7 +122,7 @@ open class Directions: NSObject {
      */
     @discardableResult open func calculate(_ options: RouteOptions, completionHandler: @escaping RouteCompletionHandler) -> URLSessionDataTask {
         options.fetchStartDate = Date()
-        let session = (options: options, credentials: self.credentials)
+        let session = (options: options as DirectionsOptions, credentials: self.credentials)
         let request = urlRequest(forCalculating: options)
         let requestTask = URLSession.shared.dataTask(with: request) { (possibleData, possibleResponse, possibleError) in
             

--- a/Sources/MapboxDirections/Directions.swift
+++ b/Sources/MapboxDirections/Directions.swift
@@ -206,7 +206,7 @@ open class Directions: NSObject {
      */
     @discardableResult open func calculate(_ options: MatchOptions, completionHandler: @escaping MatchCompletionHandler) -> URLSessionDataTask {
         options.fetchStartDate = Date()
-        let session = (options: options, credentials: self.credentials)
+        let session = (options: options as DirectionsOptions, credentials: self.credentials)
         let request = urlRequest(forCalculating: options)
         let requestTask = URLSession.shared.dataTask(with: request) { (possibleData, possibleResponse, possibleError) in
             
@@ -293,7 +293,7 @@ open class Directions: NSObject {
      */
     @discardableResult open func calculateRoutes(matching options: MatchOptions, completionHandler: @escaping RouteCompletionHandler) -> URLSessionDataTask {
         options.fetchStartDate = Date()
-        let session = (options: options, credentials: self.credentials)
+        let session = (options: options as DirectionsOptions, credentials: self.credentials)
         let request = urlRequest(forCalculating: options)
         let requestTask = URLSession.shared.dataTask(with: request) { (possibleData, possibleResponse, possibleError) in
             

--- a/Sources/MapboxDirections/Directions.swift
+++ b/Sources/MapboxDirections/Directions.swift
@@ -57,24 +57,31 @@ let userAgent: String = {
  Each result produced by the directions object is stored in a `Route` object. Depending on the `RouteOptions` object you provide, each route may include detailed information suitable for turn-by-turn directions, or it may include only high-level information such as the distance, estimated travel time, and name of each leg of the trip. The waypoints that form the request may be conflated with nearby locations, as appropriate; the resulting waypoints are provided to the closure.
  */
 open class Directions: NSObject {
-        
+    
+    /**
+     A tuple type representing the direction session that was generated from the request.
+     
+     - parameter options: A `DirectionsOptions ` object representing the request parameter options.
+     
+     - parameter credentials: A object containing the credentials used to make the request.
+     */
     public typealias Session = (options: DirectionsOptions, credentials: DirectionsCredentials)
     
     /**
      A closure (block) to be called when a directions request is complete.
      
-     - parameter response: A `RouteResponse` object that contains the entire payload of the Directions API solution. See `RouteResponse.swift` for more information.
+     - parameter session: A `Directions.Session` object containing session information
      
-     - parameter error: The error that occurred, or `nil` if the solution was obtained successfully.
+     - parameter  result: A `Result` enum that represents the `RouteResponse` if the request returned successfully, or the error if it did not.
      */
     public typealias RouteCompletionHandler = (_ session: Session, _ result: Result<RouteResponse, DirectionsError>) -> Void
     
     /**
      A closure (block) to be called when a map matching request is complete.
      
-     - parameter response: A `MapMatchingResponse` object that contains the entire payload of the Directions Map Matching API solution. See `MapMatchingResponse.swift` for more information.
-
-     - parameter error: The error that occurred, or `nil` if the solution was obtained successfully.
+     - parameter session: A `Directions.Session` object containing session information
+     
+     - parameter  result: A `Result` enum that represents the `MapMatchingResponse` if the request returned successfully, or the error if it did not.
      */
     public typealias MatchCompletionHandler = (_ session: Session, _ result: Result<MapMatchingResponse, DirectionsError>) -> Void
     

--- a/Sources/MapboxDirections/Directions.swift
+++ b/Sources/MapboxDirections/Directions.swift
@@ -57,9 +57,7 @@ let userAgent: String = {
  Each result produced by the directions object is stored in a `Route` object. Depending on the `RouteOptions` object you provide, each route may include detailed information suitable for turn-by-turn directions, or it may include only high-level information such as the distance, estimated travel time, and name of each leg of the trip. The waypoints that form the request may be conflated with nearby locations, as appropriate; the resulting waypoints are provided to the closure.
  */
 open class Directions: NSObject {
-    
-    public typealias MapMatchingError = (response: MapMatchingResponse, error: DirectionsError)
-    
+        
     public typealias Session = (options: DirectionsOptions, credentials: DirectionsCredentials)
     
     /**

--- a/Sources/MapboxDirections/DirectionsCredentials.swift
+++ b/Sources/MapboxDirections/DirectionsCredentials.swift
@@ -31,8 +31,8 @@ public struct DirectionsCredentials: Equatable {
      - parameter accessToken: Optional. An access token to provide. If this value is nil, the SDK will attempt to find a token from your app's `info.plist`.
      - parameter host: Optional. A parameter to pass a custom host. If `nil` is provided, the SDK will attempt to find a host from your app's `info.plist`, and barring that will default to  `https://api.mapbox.com`.
      */
-    public init(accessToken: String? = nil, host: URL? = nil) {
-        self.accessToken = accessToken ?? defaultAccessToken
+    public init(accessToken token: String? = nil, host: URL? = nil) {
+        accessToken = token ?? defaultAccessToken
         
         precondition(accessToken != nil && !accessToken!.isEmpty, "A Mapbox access token is required. Go to <https://account.mapbox.com/access-tokens/>. In Info.plist, set the MGLMapboxAccessToken key to your access token, or use the Directions(accessToken:host:) initializer.")
         

--- a/Sources/MapboxDirections/DirectionsCredentials.swift
+++ b/Sources/MapboxDirections/DirectionsCredentials.swift
@@ -32,10 +32,10 @@ public struct DirectionsCredentials: Equatable {
      - parameter host: Optional. A parameter to pass a custom host. If `nil` is provided, the SDK will attempt to find a host from your app's `info.plist`, and barring that will default to  `https://api.mapbox.com`.
      */
     public init(accessToken token: String? = nil, host: URL? = nil) {
-        accessToken = token ?? defaultAccessToken
+        let accessToken = token ?? defaultAccessToken
         
         precondition(accessToken != nil && !accessToken!.isEmpty, "A Mapbox access token is required. Go to <https://account.mapbox.com/access-tokens/>. In Info.plist, set the MGLMapboxAccessToken key to your access token, or use the Directions(accessToken:host:) initializer.")
-        
+        self.accessToken = accessToken
         if let host = host {
             self.host = host
         } else if let defaultHostString = defaultApiEndPointURLString, let defaultHost = URL(string: defaultHostString) {

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -72,7 +72,12 @@ open class RouteOptions: DirectionsOptions {
         try super.init(from: decoder)
     }
     
-    internal convenience init(matchOptions: MatchOptions) {
+    /**
+     Initializes an equivalent route options object from a match options object. Desirable for building a navigation experience from map matching.
+
+     - parameter matchOptions: The `MatchOptions` that is being used to convert to a `RouteOptions` object.
+     */
+    public convenience init(matchOptions: MatchOptions) {
         self.init(waypoints: matchOptions.waypoints, profileIdentifier: matchOptions.profileIdentifier)
         self.includesSteps = matchOptions.includesSteps
         self.shapeFormat = matchOptions.shapeFormat

--- a/Sources/MapboxDirections/RouteResponse.swift
+++ b/Sources/MapboxDirections/RouteResponse.swift
@@ -61,7 +61,8 @@ extension RouteResponse: Codable {
         var waypoints: [Waypoint]?
         
         if let tracepoints = response.tracepoints {
-            let tracepointsData = try encoder.encode(tracepoints)
+            let filtered = tracepoints.compactMap { $0 }
+            let tracepointsData = try encoder.encode(filtered)
             waypoints = try decoder.decode([Waypoint].self, from: tracepointsData)
         }
     

--- a/Sources/MapboxDirections/RouteResponse.swift
+++ b/Sources/MapboxDirections/RouteResponse.swift
@@ -49,18 +49,21 @@ extension RouteResponse: Codable {
         let encoder = JSONEncoder()
         
         decoder.userInfo[.options] = options
+        decoder.userInfo[.credentials] = credentials
         
-        let routes: [Route]? = try response.matches?.compactMap({ (match) -> Route? in
-            let json = try encoder.encode(match)
-            let route = try decoder.decode(Route.self, from: json)
-            return route
-        })
-                
-        let waypoints: [Waypoint]? = try response.tracepoints?.compactMap({ (trace) -> Waypoint? in
-            let json = try encoder.encode(trace)
-            let waypoint = try decoder.decode(Waypoint.self, from: json)
-            return waypoint
-        })
+        var routes: [Route]?
+        
+        if let matches = response.matches {
+            let matchesData = try encoder.encode(matches)
+            routes = try decoder.decode([Route].self, from: matchesData)
+        }
+        
+        var waypoints: [Waypoint]?
+        
+        if let tracepoints = response.tracepoints {
+            let tracepointsData = try encoder.encode(tracepoints)
+            waypoints = try decoder.decode([Waypoint].self, from: tracepointsData)
+        }
     
         self.init(httpResponse: response.httpResponse, identifier: nil, routes: routes, waypoints: waypoints, options: .match(options), credentials: credentials)
     }

--- a/Sources/MapboxDirections/RouteResponse.swift
+++ b/Sources/MapboxDirections/RouteResponse.swift
@@ -9,7 +9,7 @@ public struct RouteResponse {
     public let httpResponse: HTTPURLResponse?
     
     public let identifier: String?
-    public let routes: [Route]?
+    public var routes: [Route]?    
     public let waypoints: [Waypoint]?
     
     public let options: ResponseOptions

--- a/Tests/MapboxDirectionsTests/AnnotationTests.swift
+++ b/Tests/MapboxDirectionsTests/AnnotationTests.swift
@@ -38,14 +38,19 @@ class AnnotationTests: XCTestCase {
         options.routeShapeResolution = .full
         options.attributeOptions = [.distance, .expectedTravelTime, .speed, .congestionLevel, .maximumSpeedLimit]
         var route: Route?
-        let task = Directions(credentials: BogusCredentials).calculate(options) { (response, error) in
-            XCTAssertNil(error, "Error: \(error!.localizedDescription)")
+        let task = Directions(credentials: BogusCredentials).calculate(options) { (session, disposition) in
             
-            XCTAssertNotNil(response.routes)
-            XCTAssertEqual(response.routes!.count, 1)
-            route = response.routes!.first!
-            
-            expectation.fulfill()
+            switch disposition {
+            case let .failure(error):
+                XCTFail("Error! \(error)")
+            case let .success(response):
+                XCTAssertNotNil(response.routes)
+                XCTAssertEqual(response.routes!.count, 1)
+                route = response.routes!.first!
+                
+                expectation.fulfill()
+            }
+
         }
         XCTAssertNotNil(task)
         

--- a/Tests/MapboxDirectionsTests/DirectionsTests.swift
+++ b/Tests/MapboxDirectionsTests/DirectionsTests.swift
@@ -118,7 +118,7 @@ class DirectionsTests: XCTestCase {
         let directions = Directions(credentials: BogusCredentials)
         let opts = RouteOptions(locations: [one, two])
         directions.calculate(opts, completionHandler: { (session, result) in
-            expectation.fulfill()
+            defer { expectation.fulfill() }
             
             guard case let .failure(error) = result else {
                 XCTFail("Expecting an error, none returned. \(result)")
@@ -165,7 +165,7 @@ class DirectionsTests: XCTestCase {
         let directions = Directions(credentials: BogusCredentials)
         let opts = RouteOptions(locations: [one, two])
         directions.calculate(opts, completionHandler: { (session, result) in
-            expectation.fulfill()
+            defer { expectation.fulfill() }
             
             guard case let .failure(error) = result else {
                 XCTFail("Error expected, none returned. \(result)")

--- a/Tests/MapboxDirectionsTests/MatchTests.swift
+++ b/Tests/MapboxDirectionsTests/MatchTests.swift
@@ -35,9 +35,13 @@ class MatchTests: XCTestCase {
         matchOptions.includesSteps = true
         matchOptions.routeShapeResolution = .full
         
-        let task = Directions(credentials: BogusCredentials).calculate(matchOptions) { (resp, error) in
-            XCTAssertNil(error, "Error: \(error!)")
+        let task = Directions(credentials: BogusCredentials).calculate(matchOptions) { (session, result) in
             
+            guard case let .success(resp) = result else {
+                XCTFail("Encountered unexpected error. \(result)")
+                return
+            }
+                    
             response = resp
             
             expectation.fulfill()
@@ -120,8 +124,12 @@ class MatchTests: XCTestCase {
         matchOptions.includesSteps = true
         matchOptions.routeShapeResolution = .full
         
-        let task = Directions(credentials: BogusCredentials).calculate(matchOptions) { (resp, error) in
-            XCTAssertNil(error, "Error: \(error!)")
+        let task = Directions(credentials: BogusCredentials).calculate(matchOptions) { (session, result) in
+            guard case let .success(resp) = result else {
+                XCTFail("Encountered unexpected error. \(result)")
+                return
+            }
+            
             response = resp
             expectation.fulfill()
         }

--- a/Tests/MapboxDirectionsTests/RoutableMatchTests.swift
+++ b/Tests/MapboxDirectionsTests/RoutableMatchTests.swift
@@ -35,12 +35,16 @@ class RoutableMatchTest: XCTestCase {
             waypoint.separatesLegs = false
         }
         
-        let task = Directions(credentials: BogusCredentials).calculateRoutes(matching: matchOptions) { (response, error) in
-            XCTAssertNil(error, "Error: \(error!)")
+        let task = Directions(credentials: BogusCredentials).calculateRoutes(matching: matchOptions) { (session, result) in
             
-            routeResponse = response
-            
-            expectation.fulfill()
+            switch (result) {
+            case let .failure(error):
+                XCTFail("Error: \(error)")
+            case let .success(response):
+                routeResponse = response
+                expectation.fulfill()
+            }
+                        
         }
         XCTAssertNotNil(task)
         

--- a/Tests/MapboxDirectionsTests/V5Tests.swift
+++ b/Tests/MapboxDirectionsTests/V5Tests.swift
@@ -48,12 +48,15 @@ class V5Tests: XCTestCase {
         options.locale = Locale(identifier: "en_US")
         options.includesExitRoundaboutManeuver = true
         var response: RouteResponse!
-        let task = Directions(credentials: BogusCredentials).calculate(options) { (resp, error) in
-            XCTAssertNil(error, "Error: \(error!)")
+        let task = Directions(credentials: BogusCredentials).calculate(options) { (session, result) in
             
-            response = resp
-            
-            expectation.fulfill()
+            switch result {
+            case let .failure(error):
+                XCTFail("Error: \(error)")
+            case let .success(resp):
+                response = resp
+                expectation.fulfill()
+            }
         }
         XCTAssertNotNil(task)
         
@@ -246,9 +249,11 @@ class V5Tests: XCTestCase {
         options.includesExitRoundaboutManeuver = true
         
         var route: Route?
-        let task = Directions(credentials: BogusCredentials).calculate(options) { (response, error) in
-            XCTAssertNil(error, "Error: \(error!)")
-            
+        let task = Directions(credentials: BogusCredentials).calculate(options) { (session, result) in
+            guard case let .success(response) = result else {
+                XCTFail("Encountered unexpected error. \(result)")
+                return
+            }
             XCTAssertEqual(response.waypoints?.count, 3)
             
             XCTAssertNotNil(response.routes)

--- a/Tests/MapboxDirectionsTests/VisualInstructionTests.swift
+++ b/Tests/MapboxDirectionsTests/VisualInstructionTests.swift
@@ -96,10 +96,10 @@ class VisualInstructionsTests: XCTestCase {
         options.distanceMeasurementSystem = .imperial
         options.includesVisualInstructions = true
         var response: RouteResponse!
-        let task = Directions(credentials: BogusCredentials).calculate(options) { (session, disposition) in
+        let task = Directions(credentials: BogusCredentials).calculate(options) { (session, result) in
             
-            switch disposition {
-            case let .failure(error)
+            switch result {
+            case let .failure(error):
                 XCTFail("Error! \(error)")
             case let .success(resp):
                 response = resp
@@ -193,12 +193,14 @@ class VisualInstructionsTests: XCTestCase {
         options.includesVisualInstructions = true
         
         var response: RouteResponse!
-        let task = Directions(credentials: BogusCredentials).calculate(options) { (resp, error) in
-            XCTAssertNil(error, "Error: \(error!.localizedDescription)")
-            
-            response = resp
-            
-            expectation.fulfill()
+        let task = Directions(credentials: BogusCredentials).calculate(options) { (session, result) in
+             switch result {
+            case let .failure(error):
+                XCTFail("Error! \(error)")
+            case let .success(resp):
+                response = resp
+                expectation.fulfill()
+            }
         }
         XCTAssertNotNil(task)
         
@@ -266,8 +268,12 @@ class VisualInstructionsTests: XCTestCase {
         options.includesVisualInstructions = true
         
         var response: RouteResponse!
-        let task = Directions(credentials: BogusCredentials).calculate(options) { (resp, error) in
-            XCTAssertNil(error, "Error: \(error!.localizedDescription)")
+        let task = Directions(credentials: BogusCredentials).calculate(options) { (session, result) in
+            
+            guard case let .success(resp) = result else {
+                XCTFail("Encountered unexpected error. \(result)")
+                return
+            }
             
             response = resp
             

--- a/Tests/MapboxDirectionsTests/VisualInstructionTests.swift
+++ b/Tests/MapboxDirectionsTests/VisualInstructionTests.swift
@@ -96,12 +96,16 @@ class VisualInstructionsTests: XCTestCase {
         options.distanceMeasurementSystem = .imperial
         options.includesVisualInstructions = true
         var response: RouteResponse!
-        let task = Directions(credentials: BogusCredentials).calculate(options) { (resp, error) in
-            XCTAssertNil(error, "Error: \(error!.localizedDescription)")
+        let task = Directions(credentials: BogusCredentials).calculate(options) { (session, disposition) in
             
-            response = resp
+            switch disposition {
+            case let .failure(error)
+                XCTFail("Error! \(error)")
+            case let .success(resp):
+                response = resp
+                expectation.fulfill()
+            }
             
-            expectation.fulfill()
         }
         XCTAssertNotNil(task)
         


### PR DESCRIPTION
Using `Foundation.Result` as the base type returned in `Directions.calculate`. Implements #414. Thanks @SebastianOsinski!

To-Do: 
- [x] Finish fixing tests
- [x] Update docs

/cc @mapbox/navigation-ios 