### PR TITLE
Roundtrip null voiceLocale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to Mapbox Directions for Swift
 
+## master
+
+* Fixed an issue where decoding and reencoding a JSON-formatted response from the Mapbox Directions API would cause the `voiceLocale` property to be omitted from route objects. ([#424](https://github.com/mapbox/mapbox-directions-swift/pull/424))
+
 ## v0.32.0
 
 * Removed the `CoordinateBounds` struct in favor of `BoundingBox` from Turf. ([#427](https://github.com/mapbox/mapbox-directions-swift/pull/427))

--- a/Sources/MapboxDirections/DirectionsResult.swift
+++ b/Sources/MapboxDirections/DirectionsResult.swift
@@ -77,7 +77,7 @@ open class DirectionsResult: Codable {
         try container.encode(distance, forKey: .distance)
         try container.encode(expectedTravelTime, forKey: .expectedTravelTime)
         try container.encodeIfPresent(routeIdentifier, forKey: .routeIdentifier)
-        try container.encodeIfPresent(speechLocale?.identifier, forKey: .speechLocale)
+        try container.encode(speechLocale?.identifier, forKey: .speechLocale)
     }
     
     // MARK: Getting the Shape of the Route

--- a/Sources/MapboxDirections/DirectionsResult.swift
+++ b/Sources/MapboxDirections/DirectionsResult.swift
@@ -26,7 +26,7 @@ open class DirectionsResult: Codable {
         self.shape = shape
         self.distance = distance
         self.expectedTravelTime = expectedTravelTime
-        self.speechLocaleIsSupported = false
+        self.responseContainsSpeechLocale = false
     }
     
     public required init(from decoder: Decoder) throws {
@@ -64,7 +64,7 @@ open class DirectionsResult: Codable {
             speechLocale = nil
         }
 
-        speechLocaleIsSupported = container.contains(.speechLocale)
+        responseContainsSpeechLocale = container.contains(.speechLocale)
     }
     
     
@@ -81,7 +81,7 @@ open class DirectionsResult: Codable {
         try container.encode(expectedTravelTime, forKey: .expectedTravelTime)
         try container.encodeIfPresent(routeIdentifier, forKey: .routeIdentifier)
 
-        if speechLocaleIsSupported {
+        if responseContainsSpeechLocale {
             try container.encode(speechLocale?.identifier, forKey: .speechLocale)
         }
     }
@@ -175,7 +175,14 @@ open class DirectionsResult: Codable {
      */
     open var responseEndDate: Date?
 
-    internal let speechLocaleIsSupported: Bool
+    /**
+     Internal indicator of whether response contained the `voiceLocale` entry.
+
+     Directions API includes `voiceLocale` if `voice_instructions=true` option was specified in the request.
+
+     This property persists after encoding and decoding.
+     */
+    internal let responseContainsSpeechLocale: Bool
 }
 
 extension DirectionsResult: CustomStringConvertible {

--- a/Sources/MapboxDirections/DirectionsResult.swift
+++ b/Sources/MapboxDirections/DirectionsResult.swift
@@ -26,6 +26,7 @@ open class DirectionsResult: Codable {
         self.shape = shape
         self.distance = distance
         self.expectedTravelTime = expectedTravelTime
+        self.speechLocaleIsSupported = false
     }
     
     public required init(from decoder: Decoder) throws {
@@ -62,6 +63,8 @@ open class DirectionsResult: Codable {
         } else {
             speechLocale = nil
         }
+
+        speechLocaleIsSupported = container.contains(.speechLocale)
     }
     
     
@@ -77,7 +80,10 @@ open class DirectionsResult: Codable {
         try container.encode(distance, forKey: .distance)
         try container.encode(expectedTravelTime, forKey: .expectedTravelTime)
         try container.encodeIfPresent(routeIdentifier, forKey: .routeIdentifier)
-        try container.encode(speechLocale?.identifier, forKey: .speechLocale)
+
+        if speechLocaleIsSupported {
+            try container.encode(speechLocale?.identifier, forKey: .speechLocale)
+        }
     }
     
     // MARK: Getting the Shape of the Route
@@ -168,6 +174,8 @@ open class DirectionsResult: Codable {
      This property does not persist after encoding and decoding.
      */
     open var responseEndDate: Date?
+
+    internal let speechLocaleIsSupported: Bool
 }
 
 extension DirectionsResult: CustomStringConvertible {

--- a/Sources/MapboxDirections/MapMatching/Match.swift
+++ b/Sources/MapboxDirections/MapMatching/Match.swift
@@ -111,6 +111,7 @@ extension Match: Equatable {
             lhs.distance == rhs.distance &&
             lhs.expectedTravelTime == rhs.expectedTravelTime &&
             lhs.speechLocale == rhs.speechLocale &&
+            lhs.speechLocaleIsSupported == rhs.speechLocaleIsSupported &&
             lhs.confidence == rhs.confidence &&
             lhs.weight == rhs.weight &&
             lhs.legs == rhs.legs &&

--- a/Sources/MapboxDirections/MapMatching/Match.swift
+++ b/Sources/MapboxDirections/MapMatching/Match.swift
@@ -111,7 +111,7 @@ extension Match: Equatable {
             lhs.distance == rhs.distance &&
             lhs.expectedTravelTime == rhs.expectedTravelTime &&
             lhs.speechLocale == rhs.speechLocale &&
-            lhs.speechLocaleIsSupported == rhs.speechLocaleIsSupported &&
+            lhs.responseContainsSpeechLocale == rhs.responseContainsSpeechLocale &&
             lhs.confidence == rhs.confidence &&
             lhs.weight == rhs.weight &&
             lhs.legs == rhs.legs &&

--- a/Sources/MapboxDirections/Route.swift
+++ b/Sources/MapboxDirections/Route.swift
@@ -15,7 +15,7 @@ extension Route: Equatable {
             lhs.distance == rhs.distance &&
             lhs.expectedTravelTime == rhs.expectedTravelTime &&
             lhs.speechLocale == rhs.speechLocale &&
-            lhs.speechLocaleIsSupported == rhs.speechLocaleIsSupported &&
+            lhs.responseContainsSpeechLocale == rhs.responseContainsSpeechLocale &&
             lhs.legs == rhs.legs &&
             lhs.shape == rhs.shape
     }

--- a/Sources/MapboxDirections/Route.swift
+++ b/Sources/MapboxDirections/Route.swift
@@ -15,6 +15,7 @@ extension Route: Equatable {
             lhs.distance == rhs.distance &&
             lhs.expectedTravelTime == rhs.expectedTravelTime &&
             lhs.speechLocale == rhs.speechLocale &&
+            lhs.speechLocaleIsSupported == rhs.speechLocaleIsSupported &&
             lhs.legs == rhs.legs &&
             lhs.shape == rhs.shape
     }


### PR DESCRIPTION
This PR adds an internal property `speechLocaleIsSupported` to `DirectionsResult` which indicates whether the "voiceLocale" key was present in the original response.
This helps to encode the `DirectionsResult` object saving the original "voiceLocale" key-value or its absence.

The question we have to resolve to move this PR from the draft state is whether there's an external need for the `speechLocaleIsSupported` knowledge so we should either leave it `internal` or make it `public` and utilize it wherever needed.

cc: @mapbox/navigation-ios

Resolves https://github.com/mapbox/mapbox-directions-swift/issues/415