### PR TITLE
Turf update

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "raphaelmor/Polyline" ~> 4.2
-github "mapbox/turf-swift" ~> 0.3
+github "mapbox/turf-swift" ~> 0.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "5.9.0"
 github "linksmt/OHHTTPStubs" "563f48d3fab84ef04639649c770b00f4fa502cca"
-github "mapbox/turf-swift" "v0.3.0"
+github "mapbox/turf-swift" "v0.4.0"
 github "raphaelmor/Polyline" "v4.2.1"

--- a/MapboxDirections.podspec
+++ b/MapboxDirections.podspec
@@ -46,6 +46,6 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
 
   s.dependency "Polyline", "~> 4.2"
-  s.dependency "Turf", "~> 0.3"
+  s.dependency "Turf", "~> 0.4"
 
 end

--- a/Sources/MapboxDirections/CoordinateBounds.swift
+++ b/Sources/MapboxDirections/CoordinateBounds.swift
@@ -59,13 +59,51 @@ extension CoordinateBounds: Codable {
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        southWest = try container.decode(CLLocationCoordinate2D.self, forKey: .southWest)
-        northEast = try container.decode(CLLocationCoordinate2D.self, forKey: .northEast)
+        southWest = try container.decode(CLLocationCoordinate2DCodable.self, forKey: .southWest).decodedCoordinates
+        northEast = try container.decode(CLLocationCoordinate2DCodable.self, forKey: .northEast).decodedCoordinates
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(southWest.codableCoordinates)
+        try container.encode(northEast.codableCoordinates)
     }
 }
 
 extension CoordinateBounds: CustomStringConvertible {
     public var description: String {
         return "\(southWest.longitude),\(southWest.latitude);\(northEast.longitude),\(northEast.latitude)"
+    }
+}
+
+struct CLLocationCoordinate2DCodable: Codable {
+    var latitude: CLLocationDegrees
+    var longitude: CLLocationDegrees
+    var decodedCoordinates: CLLocationCoordinate2D {
+        return CLLocationCoordinate2D(latitude: latitude,
+                                      longitude: longitude)
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(longitude)
+        try container.encode(latitude)
+    }
+    
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        longitude = try container.decode(CLLocationDegrees.self)
+        latitude = try container.decode(CLLocationDegrees.self)
+    }
+    
+    init(_ coordinate: CLLocationCoordinate2D) {
+        latitude = coordinate.latitude
+        longitude = coordinate.longitude
+    }
+}
+
+extension CLLocationCoordinate2D {
+    var codableCoordinates: CLLocationCoordinate2DCodable {
+        return CLLocationCoordinate2DCodable(self)
     }
 }

--- a/Sources/MapboxDirections/DirectionsResult.swift
+++ b/Sources/MapboxDirections/DirectionsResult.swift
@@ -1,7 +1,7 @@
 import Foundation
-import struct Polyline.Polyline
+import Polyline
 import CoreLocation
-import struct Turf.LineString
+import Turf
 
 /**
  A `DirectionsResult` represents a result returned from either the Mapbox Directions service.

--- a/Sources/MapboxDirections/Extensions/Codable.swift
+++ b/Sources/MapboxDirections/Extensions/Codable.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Polyline
-import struct Turf.LineString
+import Turf
 
 extension LineString {
     /**

--- a/Sources/MapboxDirections/Extensions/Codable.swift
+++ b/Sources/MapboxDirections/Extensions/Codable.swift
@@ -28,12 +28,18 @@ enum PolyLineString {
 }
 
 extension PolyLineString: Codable {
+    private enum LineStringCodingKeys: String, CodingKey {
+        case coordinates
+    }
+    
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let options = decoder.userInfo[.options] as? DirectionsOptions
         switch options?.shapeFormat ?? .default {
         case .geoJSON:
-            self = .lineString(try container.decode(LineString.self))
+            let lineStringContainer = try decoder.container(keyedBy: LineStringCodingKeys.self)
+            let coordinates = try lineStringContainer.decode([CLLocationCoordinate2DCodable].self, forKey: .coordinates).map { $0.decodedCoordinates }
+            self = .lineString(LineString(coordinates))
         case .polyline, .polyline6:
             let precision = options?.shapeFormat == .polyline6 ? 1e6 : 1e5
             let encodedPolyline = try container.decode(String.self)
@@ -45,7 +51,8 @@ extension PolyLineString: Codable {
         var container = encoder.singleValueContainer()
         switch self {
         case let .lineString(lineString):
-            try container.encode(lineString)
+            var lineStringContainer = encoder.container(keyedBy: LineStringCodingKeys.self)
+            try lineStringContainer.encode(lineString.coordinates.map { CLLocationCoordinate2DCodable($0) }, forKey: .coordinates)
         case let .polyline(encodedPolyline, precision: _):
             try container.encode(encodedPolyline)
         }

--- a/Sources/MapboxDirections/Extensions/GeoJSON.swift
+++ b/Sources/MapboxDirections/Extensions/GeoJSON.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreLocation
 import Polyline
-import struct Turf.LineString
+import Turf
 
 extension LineString {
     init(polyLineString: PolyLineString) throws {

--- a/Sources/MapboxDirections/Intersection.swift
+++ b/Sources/MapboxDirections/Intersection.swift
@@ -103,7 +103,7 @@ extension Intersection: Codable {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(location, forKey: .location)
+        try container.encode(CLLocationCoordinate2DCodable(location), forKey: .location)
         try container.encode(headings, forKey: .headings)
         
         try container.encodeIfPresent(approachIndex, forKey: .approachIndex)
@@ -133,7 +133,7 @@ extension Intersection: Codable {
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        location = try container.decode(CLLocationCoordinate2D.self, forKey: .location)
+        location = try container.decode(CLLocationCoordinate2DCodable.self, forKey: .location).decodedCoordinates
         headings = try container.decode([CLLocationDirection].self, forKey: .headings)
         
         if let lanes = try container.decodeIfPresent([Lane].self, forKey: .lanes) {

--- a/Sources/MapboxDirections/MapMatching/Match.swift
+++ b/Sources/MapboxDirections/MapMatching/Match.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreLocation
 import Polyline
-import struct Turf.LineString
+import Turf
 
 /**
  A `Weight` enum represents the weight given to a specific match by the Directions API. The default metric is a compound index called "routability",  which is duration-based with additional penalties for less desirable maneuvers.

--- a/Sources/MapboxDirections/QuickLook.swift
+++ b/Sources/MapboxDirections/QuickLook.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Polyline
-import struct Turf.LineString
+import Turf
 
 /**
  A type with a customized Quick Look representation in the Xcode debugger.

--- a/Sources/MapboxDirections/RouteLeg.swift
+++ b/Sources/MapboxDirections/RouteLeg.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreLocation
 import Polyline
-import struct Turf.LineString
+import Turf
 
 /**
  A `RouteLeg` object defines a single leg of a route between two waypoints. If the overall route has only two waypoints, it has a single `RouteLeg` object that covers the entire route. The route leg object includes information about the leg, such as its name, distance, and expected travel time. Depending on the criteria used to calculate the route, the route leg object may also include detailed turn-by-turn instructions.

--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreLocation
 import Polyline
-import struct Turf.LineString
+import Turf
 
 /**
  A `TransportType` specifies the mode of transportation used for part of a route.

--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -519,7 +519,7 @@ open class RouteStep: Codable {
         try maneuver.encode(instructions, forKey: .instruction)
         try maneuver.encode(maneuverType, forKey: .type)
         try maneuver.encodeIfPresent(maneuverDirection, forKey: .direction)
-        try maneuver.encodeIfPresent(maneuverLocation, forKey: .location)
+        try maneuver.encode(CLLocationCoordinate2DCodable(maneuverLocation), forKey: .location)
         try maneuver.encodeIfPresent(initialHeading, forKey: .initialHeading)
         try maneuver.encodeIfPresent(finalHeading, forKey: .finalHeading)
         
@@ -534,7 +534,7 @@ open class RouteStep: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let maneuver = try container.nestedContainer(keyedBy: ManeuverCodingKeys.self, forKey: .maneuver)
         
-        maneuverLocation = try maneuver.decode(CLLocationCoordinate2D.self, forKey: .location)
+        maneuverLocation = try maneuver.decode(CLLocationCoordinate2DCodable.self, forKey: .location).decodedCoordinates
         maneuverType = (try? maneuver.decode(ManeuverType.self, forKey: .type)) ?? .default
         maneuverDirection = try maneuver.decodeIfPresent(ManeuverDirection.self, forKey: .direction)
         

--- a/Sources/MapboxDirections/Waypoint.swift
+++ b/Sources/MapboxDirections/Waypoint.swift
@@ -20,11 +20,11 @@ public class Waypoint: Codable {
     required public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
-        coordinate = try container.decode(CLLocationCoordinate2D.self, forKey: .coordinate)
+        coordinate = try container.decode(CLLocationCoordinate2DCodable.self, forKey: .coordinate).decodedCoordinates
         
         coordinateAccuracy = try container.decodeIfPresent(CLLocationAccuracy.self, forKey: .coordinateAccuracy)
         
-        targetCoordinate = try container.decodeIfPresent(CLLocationCoordinate2D.self, forKey: .targetCoordinate)
+        targetCoordinate = try container.decodeIfPresent(CLLocationCoordinate2DCodable.self, forKey: .targetCoordinate)?.decodedCoordinates
         
         heading = try container.decodeIfPresent(CLLocationDirection.self, forKey: .heading)
         
@@ -44,6 +44,20 @@ public class Waypoint: Codable {
         } else {
             name = nil
         }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        try container.encode(CLLocationCoordinate2DCodable(coordinate), forKey: .coordinate)
+        try container.encode(coordinateAccuracy, forKey: .coordinateAccuracy)
+        let targetCoordinateCodable = targetCoordinate != nil ? CLLocationCoordinate2DCodable(targetCoordinate!) : nil
+        try container.encode(targetCoordinateCodable, forKey: .targetCoordinate)
+        try container.encodeIfPresent(heading, forKey: .heading)
+        try container.encodeIfPresent(headingAccuracy, forKey: .headingAccuracy)
+        try container.encodeIfPresent(separatesLegs, forKey: .separatesLegs)
+        try container.encodeIfPresent(allowsArrivingOnOppositeSide, forKey: .allowsArrivingOnOppositeSide)
+        try container.encodeIfPresent(name, forKey: .name)
     }
     
     /**

--- a/Tests/MapboxDirectionsTests/GeoJSONTests.swift
+++ b/Tests/MapboxDirectionsTests/GeoJSONTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import MapboxDirections
-import struct Turf.LineString
+import Turf
 
 class GeoJSONTests: XCTestCase {
     func testInitialization() {


### PR DESCRIPTION
Resolves #423 

Bumbed Turf version to `0.4.0`. Implemented now hidden `Codable` conformances, refined importing conflicts between `Turf` and `Polyline`.