### PR TITLE
Fix guidance views json parsing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed an issue where decoding and reencoding a JSON-formatted response from the Mapbox Directions API would cause the `voiceLocale` property to be omitted from route objects. ([#424](https://github.com/mapbox/mapbox-directions-swift/pull/424))
 * Added the `Route(legs:shape:distance:expectedTravelTime:)` and `Route(from:)` initializers. ([#430](https://github.com/mapbox/mapbox-directions-swift/pull/430))
+* Fixed an issue where `VisualInstruction.Component.guidanceView` lacked an image URL. ([#432](https://github.com/mapbox/mapbox-directions-swift/pull/432))
 
 ## v0.32.0
 

--- a/Sources/MapboxDirections/VisualInstructionComponent.swift
+++ b/Sources/MapboxDirections/VisualInstructionComponent.swift
@@ -177,7 +177,7 @@ extension VisualInstruction.Component: Codable {
         case abbreviatedText = "abbr"
         case abbreviatedTextPriority = "abbr_priority"
         case imageBaseURL
-        case imageURL = "url"
+        case imageURL
         case directions
         case isActive = "active"
     }

--- a/Tests/MapboxDirectionsTests/VisualInstructionTests.swift
+++ b/Tests/MapboxDirectionsTests/VisualInstructionTests.swift
@@ -30,7 +30,7 @@ class VisualInstructionsTests: XCTestCase {
                 [
                   "text": "CA01610_1_E",
                   "type": "guidance-view",
-                  "url": "https://www.mapbox.com/navigation"
+                  "imageURL": "https://www.mapbox.com/navigation"
                     ],
               ],
               "type": "fork",
@@ -49,13 +49,19 @@ class VisualInstructionsTests: XCTestCase {
             XCTAssertEqual(banner.primaryInstruction.maneuverDirection, .right)
             XCTAssertNil(banner.secondaryInstruction)
             XCTAssertNotNil(banner.quaternaryInstruction)
+            XCTAssertEqual(banner.quaternaryInstruction?.components.count, 1)
             XCTAssertEqual(banner.drivingSide, .default)
         }
+        
+        let componentGuidanceViewImage = banner?.quaternaryInstruction?.components.first
+        XCTAssertNotNil(componentGuidanceViewImage)
+        
         
         let component = VisualInstruction.Component.text(text: .init(text: "Weinstock Strasse", abbreviation: nil, abbreviationPriority: nil))
         let primaryInstruction = VisualInstruction(text: "Weinstock Strasse", maneuverType: .turn, maneuverDirection: .right, components: [component])
         
         let guideViewComponent = VisualInstruction.Component.guidanceView(image: GuidanceViewImageRepresentation(imageURL: URL(string: "https://www.mapbox.com/navigation")), alternativeText: VisualInstruction.Component.TextRepresentation(text: "CA01610_1_E", abbreviation: nil, abbreviationPriority: nil))
+        XCTAssert(componentGuidanceViewImage == guideViewComponent)
         let quaternaryInstruction = VisualInstruction(text: "CA01610_1_E", maneuverType: .reachFork, maneuverDirection: .right, components: [guideViewComponent])
         
         banner = VisualInstructionBanner(distanceAlongStep: 393.3, primary: primaryInstruction, secondary: nil, tertiary: nil, quaternary: quaternaryInstruction, drivingSide: .right)


### PR DESCRIPTION
Fixes an issue that caused the image url in guidance views to be nil.