### PR TITLE
Specify patch version for pre-v1.0 dependency on Turf

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "raphaelmor/Polyline" ~> 4.2
-github "mapbox/turf-swift" ~> 0.5
+github "mapbox/turf-swift" ~> 0.5.0

--- a/MapboxDirections.podspec
+++ b/MapboxDirections.podspec
@@ -46,6 +46,6 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
 
   s.dependency "Polyline", "~> 4.2"
-  s.dependency "Turf", "~> 0.5"
+  s.dependency "Turf", "~> 0.5.0"
 
 end


### PR DESCRIPTION
We need to specify the patch version for any pre-v1.0 dependency. Otherwise, both Carthage and CocoaPods will automatically pull down a newer minor version, such as Turf v0.6, which could introduce binary incompatibility even without a new release of MapboxDirections.

We haven’t been seeing the issue locally in this repository because of the Cartfile.resolved file. However, Carthage doesn’t look at that file when installing dependencies for downstream projects.

/ref #382 https://github.com/mapbox/mapbox-directions-swift/pull/441#discussion_r463834975
/cc @mapbox/navigation-ios