### PR TITLE
Patch up single-coordinate LineStrings decoded from Polylines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added the `Directions.refreshRoute(responseIdentifier:routeIndex:fromLegAtIndex:completionHandler:)` method for refreshing attributes along the legs of a route and the `Route.refreshLegAttributes(from:)` method for merging the refreshed attributes into an existing route. To enable route refreshing for the routes in a particular route response, set `RouteOptions.refreshingEnabled` to `true` before passing the `RouteOptions` object into `Directions.calculate(_:completionHandler:)`. ([#420](https://github.com/mapbox/mapbox-directions-swift/pull/420))
 * Fixed a crash that could occur if the Mapbox Directions API includes unrecognized `RoadClasses` values in its response. ([#450](https://github.com/mapbox/mapbox-directions-swift/pull/450))
+* Fixed malformed `RouteStep.shape` values that could occur when `RouteStep.maneuverType` is `ManeuverType.arrive`, `DirectionsOptions.shapeFormat` is `RouteShapeFormat.polyline6`, and the Mapbox Directions API returns certain encoded Polyline strings. ([#456](https://github.com/mapbox/mapbox-directions-swift/pull/456))
 
 ## v0.33.2
 

--- a/Sources/MapboxDirections/Extensions/GeoJSON.swift
+++ b/Sources/MapboxDirections/Extensions/GeoJSON.swift
@@ -20,8 +20,14 @@ extension LineString {
     }
     
     init(encodedPolyline: String, precision: Double) throws {
-        guard let coordinates = decodePolyline(encodedPolyline, precision: precision) as [CLLocationCoordinate2D]? else {
+        guard var coordinates = decodePolyline(encodedPolyline, precision: precision) as [CLLocationCoordinate2D]? else {
             throw GeometryError.cannotDecodePolyline(precision: precision)
+        }
+        // If the polyline has zero length with both endpoints at the same coordinate, Polyline drops one of the coordinates.
+        // https://github.com/raphaelmor/Polyline/issues/59
+        // Duplicate the coordinate to ensure a valid GeoJSON geometry.
+        if coordinates.count == 1 {
+            coordinates.append(coordinates[0])
         }
         self.init(coordinates)
     }

--- a/Tests/MapboxDirectionsTests/GeoJSONTests.swift
+++ b/Tests/MapboxDirectionsTests/GeoJSONTests.swift
@@ -15,4 +15,23 @@ class GeoJSONTests: XCTestCase {
         XCTAssertEqual(lineString?.coordinates.last?.latitude ?? 0.0, 39.276635, accuracy: 1e-5)
         XCTAssertEqual(lineString?.coordinates.last?.longitude ?? 0.0, -84.411148, accuracy: 1e-5)
     }
+    
+    func testZeroLengthWorkaround() {
+        var lineString: LineString? = nil
+        
+        // Correctly encoded zero-length LineString
+        // https://github.com/mapbox/mapbox-navigation-ios/issues/2611
+        XCTAssertNoThrow(lineString = try LineString(encodedPolyline: "s{byuAnigzhF??", precision: 1e6))
+        XCTAssertNotNil(lineString)
+        XCTAssertEqual(lineString?.coordinates.count, 2)
+        XCTAssertEqual(lineString?.coordinates.first, lineString?.coordinates.last)
+        XCTAssertEqual(lineString?.polylineEncodedString(precision: 1e6), "s{byuAnigzhF??")
+        
+        // Incorrectly encoded zero-length LineString
+        XCTAssertNoThrow(lineString = try LineString(encodedPolyline: "s{byuArigzhF", precision: 1e6))
+        XCTAssertNotNil(lineString)
+        XCTAssertEqual(lineString?.coordinates.count, 2)
+        XCTAssertEqual(lineString?.coordinates.first, lineString?.coordinates.last)
+        XCTAssertEqual(lineString?.polylineEncodedString(precision: 1e6), "s{byuArigzhF??")
+    }
 }


### PR DESCRIPTION
Fixed malformed `RouteStep.shape` values that could occur when `RouteStep.maneuverType` is `ManeuverType.arrive`, `DirectionsOptions.shapeFormat` is `RouteShapeFormat.polyline6`, and the Mapbox Directions API returns certain encoded Polyline strings. This is a defensive workaround for a potential server-side issue: even though the geometry doesn’t exactly round-trip from Polyline string to Turf LineString to Polyline string, this fix takes advantage of the fact that a single-coordinate LineString is never a correct representation of a linear feature anyways.

/cc @mapbox/navigation-ios @d-prukop @danpat @karimnaaji