### PR TITLE
Republicize DirectionsOptions.urlQueryItems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added the `Directions.refreshRoute(responseIdentifier:routeIndex:fromLegAtIndex:completionHandler:)` method for refreshing attributes along the legs of a route and the `Route.refreshLegAttributes(from:)` method for merging the refreshed attributes into an existing route. To enable route refreshing for the routes in a particular route response, set `RouteOptions.refreshingEnabled` to `true` before passing the `RouteOptions` object into `Directions.calculate(_:completionHandler:)`. ([#420](https://github.com/mapbox/mapbox-directions-swift/pull/420))
 * Fixed a crash that could occur if the Mapbox Directions API includes unrecognized `RoadClasses` values in its response. ([#450](https://github.com/mapbox/mapbox-directions-swift/pull/450))
 * Fixed malformed `RouteStep.shape` values that could occur when `RouteStep.maneuverType` is `ManeuverType.arrive`, `DirectionsOptions.shapeFormat` is `RouteShapeFormat.polyline6`, and the Mapbox Directions API returns certain encoded Polyline strings. ([#456](https://github.com/mapbox/mapbox-directions-swift/pull/456))
+* Restored the `DirectionsOptions.urlQueryItems` property so that subclasses of `RouteOptions` and `MatchOptions` can add any additional URL query parameters that are supported by the Mapbox Directions and Map Matching APIs. ([#461](https://github.com/mapbox/mapbox-directions-swift/pull/461))
 
 ## v0.33.2
 

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -312,7 +312,12 @@ open class DirectionsOptions: Codable {
         return "\(abridgedPath)/\(coordinates).json"
     }
     
-    var urlQueryItems: [URLQueryItem] {
+    /**
+     An array of URL query items (parameters) to include in an HTTP request.
+     
+     The query items are included in the URL of a GET request or the body of a POST request.
+     */
+    open var urlQueryItems: [URLQueryItem] {
         var queryItems: [URLQueryItem] = [
             URLQueryItem(name: "geometries", value: shapeFormat.rawValue),
             URLQueryItem(name: "overview", value: routeShapeResolution.rawValue),

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -172,10 +172,7 @@ open class RouteOptions: DirectionsOptions {
     
     // MARK: Getting the Request URL
     
-    /**
-     An array of URL parameters to include in the request URL.
-     */
-    override var urlQueryItems: [URLQueryItem] {
+    override open var urlQueryItems: [URLQueryItem] {
         var params: [URLQueryItem] = [
             URLQueryItem(name: "alternatives", value: String(includesAlternativeRoutes)),
             URLQueryItem(name: "continue_straight", value: String(!allowsUTurnAtWaypoint)),


### PR DESCRIPTION
Made `DirectionsOptions.urlQueryItems` open once again.

Fixes #460.

/cc @mapbox/navigation-ios @jmkiley @captainbarbosa @geografa