### PR TITLE
Update CircleCI to include an Xcode 12 build and drop Xcode 10 CI job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,10 +87,10 @@ jobs:
       - run:
           name: Dependencies
           command: |
-            ./scripts/wcarthage bootstrap --platform ios --cache-builds --configuration Debug --no-use-binaries
-            ./scripts/wcarthage bootstrap --platform tvos --cache-builds --configuration Debug --no-use-binaries
-            ./scripts/wcarthage bootstrap --platform macos --cache-builds --configuration Debug --no-use-binaries
-            ./scripts/wcarthage bootstrap --platform watchos --cache-builds --configuration Debug --no-use-binaries
+            ./scripts/wcarthage.sh bootstrap --platform ios --cache-builds --configuration Debug --no-use-binaries
+            ./scripts/wcarthage.sh bootstrap --platform tvos --cache-builds --configuration Debug --no-use-binaries
+            ./scripts/wcarthage.sh bootstrap --platform macos --cache-builds --configuration Debug --no-use-binaries
+            ./scripts/wcarthage.sh bootstrap --platform watchos --cache-builds --configuration Debug --no-use-binaries
       - run:
           name: iOS
           command: xcodebuild -sdk iphonesimulator -project MapboxDirections.xcodeproj -scheme 'MapboxDirections iOS' -destination 'platform=iOS Simulator,OS=<< parameters.iOS >>,name=<< parameters.device >>' clean build <<# parameters.test >>test<</ parameters.test >><<# parameters.codecoverage >> -enableCodeCoverage "YES"<</ parameters.codecoverage >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,10 +87,10 @@ jobs:
       - run:
           name: Dependencies
           command: |
-            carthage bootstrap --platform ios --cache-builds --configuration Debug --no-use-binaries
-            carthage bootstrap --platform tvos --cache-builds --configuration Debug --no-use-binaries
-            carthage bootstrap --platform macos --cache-builds --configuration Debug --no-use-binaries
-            carthage bootstrap --platform watchos --cache-builds --configuration Debug --no-use-binaries
+            ./scripts/wcarthage bootstrap --platform ios --cache-builds --configuration Debug --no-use-binaries
+            ./scripts/wcarthage bootstrap --platform tvos --cache-builds --configuration Debug --no-use-binaries
+            ./scripts/wcarthage bootstrap --platform macos --cache-builds --configuration Debug --no-use-binaries
+            ./scripts/wcarthage bootstrap --platform watchos --cache-builds --configuration Debug --no-use-binaries
       - run:
           name: iOS
           command: xcodebuild -sdk iphonesimulator -project MapboxDirections.xcodeproj -scheme 'MapboxDirections iOS' -destination 'platform=iOS Simulator,OS=<< parameters.iOS >>,name=<< parameters.device >>' clean build <<# parameters.test >>test<</ parameters.test >><<# parameters.codecoverage >> -enableCodeCoverage "YES"<</ parameters.codecoverage >>
@@ -117,18 +117,18 @@ workflows:
   workflow:
     jobs:
       - build-job:
+          name: "Xcode_12.1"
+          xcode: "12.0.0"
+          iOS: "14.0"
+          tvOS: "14.0"
+          watchOS: "7.0"
+      - build-job:
           name: "Xcode_11.1"
           xcode: "11.1.0"
           iOS: "13.1"
           tvOS: "13.0"
           watchOS: "6.0"
-      - build-job:
-          name: "Xcode_10.2"
-          xcode: "10.2.0"
-          iOS: "12.2"
-          tvOS: "12.2"
-          watchOS: "5.2"
           codecoverage: true
       - spm-job:
           name: "SPM_build"
-          xcode: "10.2.0"
+          xcode: "12.0.0"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Or in your [Swift Package Manager](https://swift.org/package-manager/) Package.s
 
 Then `import MapboxDirections`.
 
+This library requires Xcode 11 or higher in order to build.
 This library supports a minimum deployment target of iOS 10.0 or above, macOS 10.12.0 or above, tvOS 10.0 or above, or watchOS 2.0 or above. v0.30.0 is the last release of MapboxDirections.swift that supports a minimum deployment target of iOS 9._x_, macOS 10.11._x_, tvOS 9._x_, or watchOS 2._x_. v0.30.0 is also the last release that is compatible with Objective-C or AppleScript code.
 
 This repository contains an example application that demonstrates how to use the framework. To run it, you need to use [Carthage](https://github.com/Carthage/Carthage) 0.19 or above to install the dependencies. Detailed documentation is available in the [Mapbox API Documentation](https://docs.mapbox.com/api/navigation/#directions).

--- a/scripts/wcarthage.sh
+++ b/scripts/wcarthage.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# BASED ON THIS COMMENT: https://github.com/Carthage/Carthage/issues/3019#issuecomment-665136323
+
+# wcarthage.sh
+# Usage example: ./wcarthage.sh update --platform ios
+
+set -euo pipefail
+
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+# Xcode 12 Beta 3:
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A8169g = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+# Xcode 12 beta 4
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A8179i = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+# Xcode 12 beta 5
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A8189h = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+# Xcode 12 beta 6
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A8189n = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+# Xcode 12 GM (12A7208)
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A7208 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+# Xcode 12 GM (12A7209)
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A7209 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+# Xcode 12.0.1 GM (12A7300)
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A7300 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+# Xcode 12.1 GM (12A7403)
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A7403 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+
+
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+echo 'ONLY_ACTIVE_ARCH=NO' >> $xcconfig
+echo 'VALID_ARCHS = $(inherited) x86_64' >> $xcconfig
+
+export XCODE_XCCONFIG_FILE="$xcconfig"
+carthage $@


### PR DESCRIPTION
Update CircleCI config with newer Xcode versions and workaround for Carthage incompatibility with Xcode 12