### PR TITLE
Fix error requesting route with silent waypoints and waypoint targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## 1.2.0
 
 * Added support for encoding and decoding `Route Alerts` data coming from `Directions API`. Includes `TollCollection`, `RestStop` and `AdministrationRegion`. Also added `Incident` struct for reflecting incoming incidents along the route ([#466](https://github.com/mapbox/mapbox-directions-swift/pull/466))
+* Fixed an error that occurred when setting the Waypoint.separatesLegs property to true and setting the Waypoint.targetCoordinate property. ([#480](https://github.com/mapbox/mapbox-directions-swift/pull/480))
 
 ## 1.2.0
 

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -203,7 +203,7 @@ open class RouteOptions: DirectionsOptions {
         }
         
         if waypoints.first(where: { $0.targetCoordinate != nil }) != nil {
-            let targetCoordinates = waypoints.map { $0.targetCoordinate?.requestDescription ?? "" }.joined(separator: ";")
+            let targetCoordinates = waypoints.filter { $0.separatesLegs == true }.map { $0.targetCoordinate?.requestDescription ?? "" }.joined(separator: ";")
             params.append(URLQueryItem(name: "waypoint_targets", value: targetCoordinates))
         }
 

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -203,7 +203,7 @@ open class RouteOptions: DirectionsOptions {
         }
         
         if waypoints.first(where: { $0.targetCoordinate != nil }) != nil {
-            let targetCoordinates = waypoints.filter { $0.separatesLegs == true }.map { $0.targetCoordinate?.requestDescription ?? "" }.joined(separator: ";")
+            let targetCoordinates = waypoints.filter { $0.separatesLegs }.map { $0.targetCoordinate?.requestDescription ?? "" }.joined(separator: ";")
             params.append(URLQueryItem(name: "waypoint_targets", value: targetCoordinates))
         }
 


### PR DESCRIPTION
Resolves #479 
Added filtering silent waypoints when composing "waypoint_targets". Otherwise it added excessive entity which ruins endpoint response.

Note that [`waypoint_targets` doc](https://docs.mapbox.com/api/navigation/#directions) states that number of "targets" must match `coordinates` but in fact it produces an error if it doesn't match `waypoints` count (which in it's turn lists non-silent waypoints only). I've [reached out](https://mapbox.slack.com/archives/C03KW1JQD/p1604320592123400) to `Directions` team for clarification.