### PR TITLE
Remove public documentation about alert-related symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Changes to Mapbox Directions for Swift
-## 1.2.0
-
-* Added support for encoding and decoding `Route Alerts` data coming from `Directions API`. Includes `TollCollection`, `RestStop` and `AdministrationRegion`. Also added `Incident` struct for reflecting incoming incidents along the route ([#466](https://github.com/mapbox/mapbox-directions-swift/pull/466))
-* Fixed an error that occurred when setting the Waypoint.separatesLegs property to true and setting the Waypoint.targetCoordinate property. ([#480](https://github.com/mapbox/mapbox-directions-swift/pull/480))
 
 ## 1.2.0
 
 * Added the `DirectionsResult.typicalTravelTime`, `RouteLeg.typicalTravelTime` and `RouteStep.typicalTravelTime` properties that indicate the typical travel time, as opposed to the current expected travel time. ([#462](https://github.com/mapbox/mapbox-directions-swift/pull/462))
+* Fixed an error that occurred when setting the Waypoint.separatesLegs property to true and setting the Waypoint.targetCoordinate property. ([#480](https://github.com/mapbox/mapbox-directions-swift/pull/480))
 
 ## 1.0.0
 

--- a/Sources/MapboxDirections/AdministrationRegion.swift
+++ b/Sources/MapboxDirections/AdministrationRegion.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /**
+ :nodoc:
  `AdministrationRegion` describes corresponding object on the route.
  */
 public struct AdministrationRegion: Codable, Equatable {

--- a/Sources/MapboxDirections/Incident.swift
+++ b/Sources/MapboxDirections/Incident.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /**
+ :nodoc:
  `Incident` describes any corresponding event, used for annotating the route.
  */
 public struct Incident: Codable, Equatable {

--- a/Sources/MapboxDirections/Intersection.swift
+++ b/Sources/MapboxDirections/Intersection.swift
@@ -14,12 +14,12 @@ public struct Intersection {
                 outletIndexes: IndexSet,
                 approachLanes: [LaneIndication]?,
                 usableApproachLanes: IndexSet?,
-                outletRoadClasses: RoadClasses?,
-                tollCollection: TollCollection?,
-                tunnelName: String?,
-                restStop: RestStop?,
-                isUrban: Bool?,
-                administrationRegionIndex: Int?,
+                outletRoadClasses: RoadClasses? = nil,
+                tollCollection: TollCollection? = nil,
+                tunnelName: String? = nil,
+                restStop: RestStop? = nil,
+                isUrban: Bool? = nil,
+                administrationRegionIndex: Int? = nil,
                 geometryIndex: Int? = nil) {
         self.location = location
         self.headings = headings
@@ -86,6 +86,7 @@ public struct Intersection {
     public let outletRoadClasses: RoadClasses?
 
     /**
+     :nodoc:
      The name of the tunnel that this intersection is a part of.
 
      If this Intersection is not a tunnel entrance or exit, or if information is unavailable then this property is set to `nil`.
@@ -93,6 +94,7 @@ public struct Intersection {
     public let tunnelName: String?
 
     /**
+     :nodoc:
      The type of toll collection mechanism.
 
      If this Intersection is not a toll collection intersection, or if this information is unavailable then this property is set to `nil`.
@@ -100,6 +102,7 @@ public struct Intersection {
     public let tollCollection: TollCollection?
 
     /**
+     :nodoc:
      The type of rest stop.
 
      If this Intersection is not a rest stop, or if this information is unavailable then this property is set to `nil`.
@@ -107,13 +110,15 @@ public struct Intersection {
     public let restStop: RestStop?
 
     /**
-     The Intersection lays within the bounds of an urban zone.
+     :nodoc:
+     Whether the intersection lays within the bounds of an urban zone.
 
-     If this information is unavailable then this property is set to `nil`.
+     If this information is unavailable, then this property is set to `nil`.
      */
     public let isUrban: Bool?
 
     /**
+     :nodoc:
      The index of the item in the `administrationRegions` array that corresponds to the country code of the country that this intersection lies in.
 
      If the information is unavailable, this property is set to `nil`.

--- a/Sources/MapboxDirections/RestStop.swift
+++ b/Sources/MapboxDirections/RestStop.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /**
+ :nodoc:
  `RestStop` describes corresponding object on the route.
  */
 public struct RestStop: Codable, Equatable {

--- a/Sources/MapboxDirections/RouteLeg.swift
+++ b/Sources/MapboxDirections/RouteLeg.swift
@@ -165,6 +165,7 @@ open class RouteLeg: Codable {
     }()
     
     /**
+     :nodoc:
      Segments for each Intersection along the route.
      
      Ordered by `steps`, inside one `step` - ordered by `Intersection`.  `nil` value means no index was provided. Index values correspond to `route`'s `shape` elements.

--- a/Sources/MapboxDirections/TollCollection.swift
+++ b/Sources/MapboxDirections/TollCollection.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /**
+ :nodoc:
  `TollCollection` describes corresponding object on the route.
  */
 public struct TollCollection: Codable, Equatable {


### PR DESCRIPTION
Removed public documentation about TollCollection, RestStop, AdministrationRegion, and other symbols added in #466 in anticipation of the refinements in #482, #477, and #478. Also made alert-related arguments optional in initializers to avoid a backwards-incompatible change versus v1.0.0.

/cc @mapbox/navigation-ios @avi-c