### PR TITLE
Administrative regions by leg and intersection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed an error that occurred when setting the `Waypoint.separatesLegs` property to `true` and setting the `Waypoint.targetCoordinate` property. ([#480](https://github.com/mapbox/mapbox-directions-swift/pull/480))
 * `Directions.fetchAvailableOfflineVersions(completionHandler:)` now calls its completion handler on the main queue consistently. ([#475](https://github.com/mapbox/mapbox-directions-swift/pull/475))
 * Upgraded to Polyline v5.0.0. ([#487](https://github.com/mapbox/mapbox-directions-swift/pull/487))
+* Added `Intersection.regionCode` and `RouteStep.administrativeRegionIndicesByIntersection` for more convenient region data usage. `Intersection.administrativeRegionIndex` is now internal. ([#485](https://github.com/mapbox/mapbox-directions-swift/pull/485))
 
 ## v1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
 * Fixed an error that occurred when setting the `Waypoint.separatesLegs` property to `true` and setting the `Waypoint.targetCoordinate` property. ([#480](https://github.com/mapbox/mapbox-directions-swift/pull/480))
 * `Directions.fetchAvailableOfflineVersions(completionHandler:)` now calls its completion handler on the main queue consistently. ([#475](https://github.com/mapbox/mapbox-directions-swift/pull/475))
 * Upgraded to Polyline v5.0.0. ([#487](https://github.com/mapbox/mapbox-directions-swift/pull/487))
-* Added `Intersection.regionCode` and `RouteStep.administrativeRegionIndicesByIntersection` for more convenient region data usage. `Intersection.administrativeRegionIndex` is now internal. ([#485](https://github.com/mapbox/mapbox-directions-swift/pull/485))
-* Added `Intersection.regionCode` and `RouteStep.administrativeRegionIndicesByIntersection` for more convenient region data usage. `Intersection.administrativeRegionIndex` is removed in favor of the above, depending on needs in a string representation or index value. ([#485](https://github.com/mapbox/mapbox-directions-swift/pull/485))
 
 ## v1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Added support for building and running on any Linux distribution supported by Swift. ([#488](https://github.com/mapbox/mapbox-directions-swift/pull/488))
 * Added the `MapboxDirectionsCLI` command line tool that round-trips Mapbox Directions API responses between JSON format and Swift model objects. ([#469](https://github.com/mapbox/mapbox-directions-swift/pull/469))
 * The `CongestionLevel` enumeration now conforms to the `CaseIterable` protocol. ([#500](https://github.com/mapbox/mapbox-directions-swift/pull/500))
+* Refined encoding/decoding logic for `AdministrativeRegions` by `Leg` and `Intersection` ([#485](https://github.com/mapbox/mapbox-directions-swift/pull/485)). Added few properties for convenience access:
+    * `Intersection.regionCode` - A 2-letter region code to identify corresponding country that this intersection lies in.
+    * `RouteLeg.regionCode(atStepIndex:, intersectionIndex:)` - Returns the ISO 3166-1 alpha-2 region code for the administrative region through which the given intersection passes.
 
 ## v1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * `Directions.fetchAvailableOfflineVersions(completionHandler:)` now calls its completion handler on the main queue consistently. ([#475](https://github.com/mapbox/mapbox-directions-swift/pull/475))
 * Upgraded to Polyline v5.0.0. ([#487](https://github.com/mapbox/mapbox-directions-swift/pull/487))
 * Added `Intersection.regionCode` and `RouteStep.administrativeRegionIndicesByIntersection` for more convenient region data usage. `Intersection.administrativeRegionIndex` is now internal. ([#485](https://github.com/mapbox/mapbox-directions-swift/pull/485))
+* Added `Intersection.regionCode` and `RouteStep.administrativeRegionIndicesByIntersection` for more convenient region data usage. `Intersection.administrativeRegionIndex` is removed in favor of the above, depending on needs in a string representation or index value. ([#485](https://github.com/mapbox/mapbox-directions-swift/pull/485))
 
 ## v1.0.0
 

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -350,10 +350,10 @@
 		F4F508392524D6F10044F2D0 /* RestStop.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F508372524D6F10044F2D0 /* RestStop.swift */; };
 		F4F5083A2524D6F10044F2D0 /* RestStop.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F508372524D6F10044F2D0 /* RestStop.swift */; };
 		F4F5083B2524D6F10044F2D0 /* RestStop.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F508372524D6F10044F2D0 /* RestStop.swift */; };
-		F4F5084B2524DC280044F2D0 /* AdministrationRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F5084A2524DC280044F2D0 /* AdministrationRegion.swift */; };
-		F4F5084C2524DC280044F2D0 /* AdministrationRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F5084A2524DC280044F2D0 /* AdministrationRegion.swift */; };
-		F4F5084D2524DC280044F2D0 /* AdministrationRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F5084A2524DC280044F2D0 /* AdministrationRegion.swift */; };
-		F4F5084E2524DC280044F2D0 /* AdministrationRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F5084A2524DC280044F2D0 /* AdministrationRegion.swift */; };
+		F4F5084B2524DC280044F2D0 /* AdministrativeRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F5084A2524DC280044F2D0 /* AdministrativeRegion.swift */; };
+		F4F5084C2524DC280044F2D0 /* AdministrativeRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F5084A2524DC280044F2D0 /* AdministrativeRegion.swift */; };
+		F4F5084D2524DC280044F2D0 /* AdministrativeRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F5084A2524DC280044F2D0 /* AdministrativeRegion.swift */; };
+		F4F5084E2524DC280044F2D0 /* AdministrativeRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F5084A2524DC280044F2D0 /* AdministrativeRegion.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -564,7 +564,7 @@
 		F4CF2C562523B66300A6D0B6 /* TollCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TollCollection.swift; sourceTree = "<group>"; };
 		F4D785EE1DDD82C100FF4665 /* RouteStepTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteStepTests.swift; sourceTree = "<group>"; };
 		F4F508372524D6F10044F2D0 /* RestStop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestStop.swift; sourceTree = "<group>"; };
-		F4F5084A2524DC280044F2D0 /* AdministrationRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdministrationRegion.swift; sourceTree = "<group>"; };
+		F4F5084A2524DC280044F2D0 /* AdministrativeRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdministrativeRegion.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -810,7 +810,7 @@
 				DAC05F151CFBFAC400FA0071 /* Waypoint.swift */,
 				F4CF2C562523B66300A6D0B6 /* TollCollection.swift */,
 				F4F508372524D6F10044F2D0 /* RestStop.swift */,
-				F4F5084A2524DC280044F2D0 /* AdministrationRegion.swift */,
+				F4F5084A2524DC280044F2D0 /* AdministrativeRegion.swift */,
 				F457FA79252B9E29007DAEB1 /* Incident.swift */,
 			);
 			name = MapboxDirections;
@@ -1443,7 +1443,7 @@
 				C58EA7AB1E9D7F73008F98CE /* Congestion.swift in Sources */,
 				8D381B6B1FDB3D8A008D5A58 /* String.swift in Sources */,
 				F457FA7B252B9E29007DAEB1 /* Incident.swift in Sources */,
-				F4F5084C2524DC280044F2D0 /* AdministrationRegion.swift in Sources */,
+				F4F5084C2524DC280044F2D0 /* AdministrativeRegion.swift in Sources */,
 				438BFEC3233D854D00457294 /* DirectionsProfileIdentifier.swift in Sources */,
 				F4CF2C582523B66300A6D0B6 /* TollCollection.swift in Sources */,
 				F4F508392524D6F10044F2D0 /* RestStop.swift in Sources */,
@@ -1529,7 +1529,7 @@
 				C58EA7AC1E9D7F74008F98CE /* Congestion.swift in Sources */,
 				8D381B6C1FDB3D8B008D5A58 /* String.swift in Sources */,
 				F457FA7C252B9E29007DAEB1 /* Incident.swift in Sources */,
-				F4F5084D2524DC280044F2D0 /* AdministrationRegion.swift in Sources */,
+				F4F5084D2524DC280044F2D0 /* AdministrativeRegion.swift in Sources */,
 				438BFEC4233D854D00457294 /* DirectionsProfileIdentifier.swift in Sources */,
 				F4CF2C592523B66300A6D0B6 /* TollCollection.swift in Sources */,
 				F4F5083A2524D6F10044F2D0 /* RestStop.swift in Sources */,
@@ -1615,7 +1615,7 @@
 				C58EA7AD1E9D7F75008F98CE /* Congestion.swift in Sources */,
 				8D381B6D1FDB3D8B008D5A58 /* String.swift in Sources */,
 				F457FA7D252B9E29007DAEB1 /* Incident.swift in Sources */,
-				F4F5084E2524DC280044F2D0 /* AdministrationRegion.swift in Sources */,
+				F4F5084E2524DC280044F2D0 /* AdministrativeRegion.swift in Sources */,
 				438BFEC5233D854D00457294 /* DirectionsProfileIdentifier.swift in Sources */,
 				F4CF2C5A2523B66300A6D0B6 /* TollCollection.swift in Sources */,
 				F4F5083B2524D6F10044F2D0 /* RestStop.swift in Sources */,
@@ -1668,7 +1668,7 @@
 				C5DAAC9A20191675001F9261 /* Match.swift in Sources */,
 				C58EA7AA1E9D7EAD008F98CE /* Congestion.swift in Sources */,
 				F457FA7A252B9E29007DAEB1 /* Incident.swift in Sources */,
-				F4F5084B2524DC280044F2D0 /* AdministrationRegion.swift in Sources */,
+				F4F5084B2524DC280044F2D0 /* AdministrativeRegion.swift in Sources */,
 				8D381B6A1FDB101F008D5A58 /* String.swift in Sources */,
 				F4CF2C572523B66300A6D0B6 /* TollCollection.swift in Sources */,
 				F4F508382524D6F10044F2D0 /* RestStop.swift in Sources */,

--- a/Sources/MapboxDirections/AdministrativeRegion.swift
+++ b/Sources/MapboxDirections/AdministrativeRegion.swift
@@ -18,4 +18,18 @@ public struct AdministrativeRegion: Codable, Equatable {
         self.countryCode = countryCode
         self.countryCodeAlpha3 = countryCodeAlpha3
     }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        countryCode = try container.decode(String.self, forKey: .countryCode)
+        countryCodeAlpha3 = try container.decode(String.self, forKey: .countryCodeAlpha3)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        try container.encode(countryCode, forKey: .countryCode)
+        try container.encode(countryCodeAlpha3, forKey: .countryCodeAlpha3)
+    }
 }

--- a/Sources/MapboxDirections/AdministrativeRegion.swift
+++ b/Sources/MapboxDirections/AdministrativeRegion.swift
@@ -23,13 +23,13 @@ public struct AdministrativeRegion: Codable, Equatable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         countryCode = try container.decode(String.self, forKey: .countryCode)
-        countryCodeAlpha3 = try container.decode(String.self, forKey: .countryCodeAlpha3)
+        countryCodeAlpha3 = try container.decodeIfPresent(String.self, forKey: .countryCodeAlpha3)
     }
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         
         try container.encode(countryCode, forKey: .countryCode)
-        try container.encode(countryCodeAlpha3, forKey: .countryCodeAlpha3)
+        try container.encodeIfPresent(countryCodeAlpha3, forKey: .countryCodeAlpha3)
     }
 }

--- a/Sources/MapboxDirections/AdministrativeRegion.swift
+++ b/Sources/MapboxDirections/AdministrativeRegion.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /**
  :nodoc:
- `AdministrationRegion` describes corresponding object on the route.
+ `AdministrativeRegion` describes corresponding object on the route.
  */
-public struct AdministrationRegion: Codable, Equatable {
+public struct AdministrativeRegion: Codable, Equatable {
 
     private enum CodingKeys: String, CodingKey {
         case countryCodeAlpha3 = "iso_3166_1_alpha3"

--- a/Sources/MapboxDirections/Intersection.swift
+++ b/Sources/MapboxDirections/Intersection.swift
@@ -128,14 +128,22 @@ public struct Intersection {
 
      If the information is unavailable, this property is set to `nil`.
      */
-    let administrativeRegionIndex: Int?
+    var administrativeRegionIndex: Int?
+    
+    mutating func updateAdministrativeRegionIndex(_ adminIndex: Int?) {
+        self.administrativeRegionIndex = adminIndex
+    }
     
     /**
      A 2-letter region code to identify corresponding country that this intersection lies in.
      
      Automatically populated during decoding a `RouteLeg` object, since this is the source of all `AdministrativeRegion`s. Value is `nil` if such information is unavailable.
      */
-    public internal(set) var regionCode: String?
+    public private(set) var regionCode: String?
+    
+    mutating func updateRegionCode(_ regionCode: String?) {
+        self.regionCode = regionCode
+    }
 
     /**
      The index of the RouteStep within a RouteLeg that contains this Intersection.

--- a/Sources/MapboxDirections/Intersection.swift
+++ b/Sources/MapboxDirections/Intersection.swift
@@ -23,8 +23,9 @@ public struct Intersection {
                 tunnelName: String? = nil,
                 restStop: RestStop? = nil,
                 isUrban: Bool? = nil,
-                administrationRegionIndex: Int? = nil,
-                geometryIndex: Int? = nil) {
+                administrativeRegionIndex: Int? = nil,
+                geometryIndex: Int? = nil,
+                regionCode: String? = nil) {
         self.location = location
         self.headings = headings
         self.approachIndex = approachIndex
@@ -37,8 +38,9 @@ public struct Intersection {
         self.tunnelName = tunnelName
         self.isUrban = isUrban
         self.restStop = restStop
-        self.administrationRegionIndex = administrationRegionIndex
+        self.administrativeRegionIndex = administrativeRegionIndex
         self.geometryIndex = geometryIndex
+        self.regionCode = regionCode
     }
     
     // MARK: Getting the Location of the Intersection
@@ -122,12 +124,18 @@ public struct Intersection {
     public let isUrban: Bool?
 
     /**
-     :nodoc:
-     The index of the item in the `administrationRegions` array that corresponds to the country code of the country that this intersection lies in.
+     The index of the item in the `administrativeRegions` array that corresponds to the country code of the country that this intersection lies in.
 
      If the information is unavailable, this property is set to `nil`.
      */
-    public let administrationRegionIndex: Int?
+    let administrativeRegionIndex: Int?
+    
+    /**
+     A 2-letter region code to identify corresponding country that this intersection lies in.
+     
+     Automatically populated during decoding a `RouteLeg` object, since this is the source of all `AdministrativeRegion`s. Value is `nil` if such information is unavailable.
+     */
+    public internal(set) var regionCode: String?
 
     /**
      The index of the RouteStep within a RouteLeg that contains this Intersection.
@@ -166,7 +174,7 @@ extension Intersection: Codable {
         case tunnelName = "tunnelName"
         case isUrban = "is_urban"
         case restStop = "rest_stop"
-        case administrationRegionIndex = "admin_index"
+        case administrativeRegionIndex = "admin_index"
         case geometryIndex = "geometry_index"
     }
     
@@ -215,8 +223,8 @@ extension Intersection: Codable {
             try container.encode(tunnelName, forKey: .tunnelName)
         }
 
-        if let adminIndex = administrationRegionIndex {
-            try container.encode(adminIndex, forKey: .administrationRegionIndex)
+        if let adminIndex = administrativeRegionIndex {
+            try container.encode(adminIndex, forKey: .administrativeRegionIndex)
         }
         
         if let geoIndex = geometryIndex {
@@ -252,7 +260,7 @@ extension Intersection: Codable {
 
         restStop = try container.decodeIfPresent(RestStop.self, forKey: .restStop)
 
-        administrationRegionIndex = try container.decodeIfPresent(Int.self, forKey: .administrationRegionIndex)
+        administrativeRegionIndex = try container.decodeIfPresent(Int.self, forKey: .administrativeRegionIndex)
         
         geometryIndex = try container.decodeIfPresent(Int.self, forKey: .geometryIndex)
     }
@@ -271,7 +279,7 @@ extension Intersection: Equatable {
             lhs.tollCollection == rhs.tollCollection &&
             lhs.tunnelName == rhs.tunnelName &&
             lhs.isUrban == rhs.isUrban &&
-            lhs.administrationRegionIndex == rhs.administrationRegionIndex &&
+            lhs.administrativeRegionIndex == rhs.administrativeRegionIndex &&
             lhs.geometryIndex == rhs.geometryIndex
     }
 }

--- a/Sources/MapboxDirections/Intersection.swift
+++ b/Sources/MapboxDirections/Intersection.swift
@@ -125,6 +125,8 @@ public struct Intersection {
      A 2-letter region code to identify corresponding country that this intersection lies in.
      
      Automatically populated during decoding a `RouteLeg` object, since this is the source of all `AdministrativeRegion`s. Value is `nil` if such information is unavailable.
+     
+     - seealso: `RouteStep.regionCode(atStepIndex:, intersectionIndex:)`
      */
     public private(set) var regionCode: String?
     

--- a/Sources/MapboxDirections/Intersection.swift
+++ b/Sources/MapboxDirections/Intersection.swift
@@ -173,9 +173,9 @@ extension Intersection: Codable {
         case geometryIndex = "geometry_index"
     }
     
-    static func encode(intersections: [Intersection], to encoder: Encoder, administrativeRegionIndices: [Int?]?) throws {
+    static func encode(intersections: [Intersection], to parentContainer: inout UnkeyedEncodingContainer, administrativeRegionIndices: [Int?]?) throws {
         guard administrativeRegionIndices == nil || administrativeRegionIndices?.count == intersections.count else {
-            let error = EncodingError.Context(codingPath: encoder.codingPath,
+            let error = EncodingError.Context(codingPath: parentContainer.codingPath,
                                               debugDescription: "`administrativeRegionIndices` should be `nil` or match provided `intersections` to encode")
             throw EncodingError.invalidValue(administrativeRegionIndices as Any, error)
         }
@@ -186,7 +186,7 @@ extension Intersection: Codable {
                 adminIndex = administrativeRegionIndices?[index]
             }
             
-            try intersection.encode(to: encoder, administrativeRegionIndex: adminIndex)
+            try intersection.encode(to: parentContainer.superEncoder(), administrativeRegionIndex: adminIndex)
         }
     }
 

--- a/Sources/MapboxDirections/RouteLeg.swift
+++ b/Sources/MapboxDirections/RouteLeg.swift
@@ -252,7 +252,7 @@ open class RouteLeg: Codable {
     }
     
     /**
-     Return corresponding `iso_3166_1` encoded region code, if such information is available.
+     Returns the ISO 3166-1 alpha-2 region code for the administrative region through which the given intersection passes. The intersection is identified by its step index and intersection index.
      
      - seealso: `Intersection.regionCode`
      */
@@ -295,7 +295,10 @@ open class RouteLeg: Codable {
     open var expectedTravelTime: TimeInterval
 
     /**
-     Containts a list of `AdministrativeRegion`'s on the current leg. `nil` value means that such data is not available.
+     :nodoc:
+     The administrative regions through which the leg passes.
+          
+     This property is set to `nil` if no administrative region data is available.
      */
     open var administrativeRegions: [AdministrativeRegion]?
 

--- a/Sources/MapboxDirections/RouteLeg.swift
+++ b/Sources/MapboxDirections/RouteLeg.swift
@@ -21,7 +21,7 @@ open class RouteLeg: Codable {
         case typicalTravelTime = "duration_typical"
         case profileIdentifier
         case annotation
-        case administrationRegions = "admins"
+        case administrativeRegions = "admins"
         case incidents
     }
     
@@ -78,8 +78,16 @@ open class RouteLeg: Codable {
             self.attributes = attributes
         }
 
-        if let admins = try container.decodeIfPresent([AdministrationRegion].self, forKey: .administrationRegions) {
-            self.administrationRegions = admins
+        
+        if let admins = try container.decodeIfPresent([AdministrativeRegion].self, forKey: .administrativeRegions) {
+            self.administrativeRegions = admins
+            steps.forEach { step in
+                guard let intersections = step.intersections, let adminIndicies = step.administrativeRegionIndicesByIntersection else { return }
+                for (i, var intersection) in intersections.enumerated() {
+                    guard let administrationIndex = adminIndicies[i] else { return }
+                    intersection.regionCode = administrativeRegions![administrationIndex].countryCode
+                }
+            }
         }
 
         if let incidents = try container.decodeIfPresent([Incident].self, forKey: .incidents) {
@@ -103,8 +111,8 @@ open class RouteLeg: Codable {
             try container.encode(attributes, forKey: .annotation)
         }
 
-        if let admins = administrationRegions {
-            try container.encode(admins, forKey: .administrationRegions)
+        if let admins = administrativeRegions {
+            try container.encode(admins, forKey: .administrativeRegions)
         }
 
         if let incidents = incidents {
@@ -276,7 +284,7 @@ open class RouteLeg: Codable {
      */
     open var expectedTravelTime: TimeInterval
 
-    open var administrationRegions: [AdministrationRegion]?
+    open var administrativeRegions: [AdministrativeRegion]?
 
     open var incidents: [Incident]?
     

--- a/Sources/MapboxDirections/RouteLeg.swift
+++ b/Sources/MapboxDirections/RouteLeg.swift
@@ -278,6 +278,9 @@ open class RouteLeg: Codable {
      */
     open var expectedTravelTime: TimeInterval
 
+    /**
+     Containts a list of `AdministrativeRegion`'s on the current leg. `nil` value means that such data is not available.
+     */
     open var administrativeRegions: [AdministrativeRegion]?
 
     open var incidents: [Incident]?

--- a/Sources/MapboxDirections/RouteLeg.swift
+++ b/Sources/MapboxDirections/RouteLeg.swift
@@ -251,6 +251,22 @@ open class RouteLeg: Codable {
         }
     }
     
+    /**
+     Return corresponding `iso_3166_1` encoded region code, if such information is available.
+     
+     - seealso: `Intersection.regionCode`
+     */
+    public func regionCode(atStepIndex stepIndex: Int, intersectionIndex: Int) -> String? {
+        // check index ranges
+        guard let administrativeRegions = administrativeRegions,
+              stepIndex < steps.count,
+              intersectionIndex < steps[stepIndex].administrativeAreaContainerByIntersection?.count ?? -1,
+              let adminIndex = steps[stepIndex].administrativeAreaContainerByIntersection?[intersectionIndex] else {
+            return nil
+        }
+        return administrativeRegions[adminIndex].countryCode
+    }
+    
     // MARK: Getting Statistics About the Leg
 
     /**

--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -834,7 +834,7 @@ open class RouteStep: Codable {
      
      Array may be `nil` in case `intersections` data is not available. Array element may be `nil` if corresponding `intersection` has no `Administrative Region` assigned.
      
-    - seealso: `Intersection.regionCode`
+    - seealso: `Intersection.regionCode`, `RouteStep.regionCode(atStepIndex:, intersectionIndex:)`
     */
     public let administrativeAreaContainerByIntersection: [Int?]?
 

--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -516,7 +516,7 @@ open class RouteStep: Codable {
         if let intersectionsToEncode = intersections {
             var intersectionsContainer = container.nestedUnkeyedContainer(forKey: .intersections)
             try Intersection.encode(intersections: intersectionsToEncode,
-                                    to: intersectionsContainer.superEncoder(),
+                                    to: &intersectionsContainer,
                                     administrativeRegionIndices: administrativeRegionIndicesByIntersection)
         }
         

--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -779,6 +779,14 @@ open class RouteStep: Codable {
     public let intersections: [Intersection]?
     
     /**
+     An array of `Administrative Regions` indicies for each `intersection` along current step.
+     
+     Array may be `nil` in case `intersections` data is not available. Array element may be `nil` if corresponding `intersection` has no `Administrative Region` assigned.
+     */
+    public var administrativeRegionIndicesByIntersection: [Int?]? {
+        return intersections?.map { $0.administrativeRegionIndex }
+    }
+    /**
      The sign design standard used for speed limit signs along the step.
      
      This standard affects how corresponding speed limits in the `RouteLeg.segmentMaximumSpeedLimits` property should be displayed.

--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -460,7 +460,7 @@ open class RouteStep: Codable {
      - parameter instructionsSpokenAlongStep: Instructions about the next step’s maneuver, optimized for speech synthesis.
      - parameter instructionsDisplayedAlongStep: Instructions about the next step’s maneuver, optimized for display in real time.
      */
-    public init(transportType: TransportType, maneuverLocation: CLLocationCoordinate2D, maneuverType: ManeuverType, maneuverDirection: ManeuverDirection? = nil, instructions: String, initialHeading: CLLocationDirection? = nil, finalHeading: CLLocationDirection? = nil, drivingSide: DrivingSide, exitCodes: [String]? = nil, exitNames: [String]? = nil, phoneticExitNames: [String]? = nil, distance: CLLocationDistance, expectedTravelTime: TimeInterval, typicalTravelTime: TimeInterval? = nil, names: [String]? = nil, phoneticNames: [String]? = nil, codes: [String]? = nil, destinationCodes: [String]? = nil, destinations: [String]? = nil, intersections: [Intersection]? = nil, speedLimitSignStandard: SignStandard? = nil, speedLimitUnit: UnitSpeed? = nil, instructionsSpokenAlongStep: [SpokenInstruction]? = nil, instructionsDisplayedAlongStep: [VisualInstructionBanner]? = nil) {
+    public init(transportType: TransportType, maneuverLocation: CLLocationCoordinate2D, maneuverType: ManeuverType, maneuverDirection: ManeuverDirection? = nil, instructions: String, initialHeading: CLLocationDirection? = nil, finalHeading: CLLocationDirection? = nil, drivingSide: DrivingSide, exitCodes: [String]? = nil, exitNames: [String]? = nil, phoneticExitNames: [String]? = nil, distance: CLLocationDistance, expectedTravelTime: TimeInterval, typicalTravelTime: TimeInterval? = nil, names: [String]? = nil, phoneticNames: [String]? = nil, codes: [String]? = nil, destinationCodes: [String]? = nil, destinations: [String]? = nil, intersections: [Intersection]? = nil, speedLimitSignStandard: SignStandard? = nil, speedLimitUnit: UnitSpeed? = nil, instructionsSpokenAlongStep: [SpokenInstruction]? = nil, instructionsDisplayedAlongStep: [VisualInstructionBanner]? = nil, administrativeRegionIndicesByIntersection: [Int?]? = nil) {
         self.transportType = transportType
         self.maneuverLocation = maneuverLocation
         self.maneuverType = maneuverType
@@ -485,6 +485,7 @@ open class RouteStep: Codable {
         self.speedLimitUnit = speedLimitUnit
         self.instructionsSpokenAlongStep = instructionsSpokenAlongStep
         self.instructionsDisplayedAlongStep = instructionsDisplayedAlongStep
+        self.administrativeRegionIndicesByIntersection = administrativeRegionIndicesByIntersection
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -605,21 +606,22 @@ open class RouteStep: Codable {
         
         transportType = try container.decode(TransportType.self, forKey: .transportType)
         
+        var administrativeRegionIndices: [Int?]?
         var rawIntersections = try container.decodeIfPresent([Intersection].self, forKey: .intersections)
         if rawIntersections != nil {
             // Here we are populating `administrativeRegionIndicesByIntersection`, updating `Intersection.regionCode` and `Intersection.administrativeRegionIndex`
-            administrativeRegionIndicesByIntersection = []
+            administrativeRegionIndices = []
             for index in 0..<rawIntersections!.count {
-                administrativeRegionIndicesByIntersection?.append(rawIntersections![index].administrativeRegionIndex)
+                administrativeRegionIndices?.append(rawIntersections![index].administrativeRegionIndex)
                 if let administrativeRegions = administrativeRegions,
-                   let regionIndex = administrativeRegionIndicesByIntersection?.last,
+                   let regionIndex = administrativeRegionIndices?.last,
                    regionIndex != nil && administrativeRegions.count > regionIndex! {
                     rawIntersections![index].updateRegionCode(administrativeRegions[regionIndex!].countryCode)
                 }
                 rawIntersections![index].updateAdministrativeRegionIndex(nil)
             }
         }
-        
+        administrativeRegionIndicesByIntersection = administrativeRegionIndices
         intersections = rawIntersections
         
         let road = try Road(from: decoder)
@@ -826,7 +828,7 @@ open class RouteStep: Codable {
      
      Array may be `nil` in case `intersections` data is not available. Array element may be `nil` if corresponding `intersection` has no `Administrative Region` assigned.
      */
-    public var administrativeRegionIndicesByIntersection: [Int?]?
+    public let administrativeRegionIndicesByIntersection: [Int?]?
 
     /**
      The sign design standard used for speed limit signs along the step.

--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -460,7 +460,7 @@ open class RouteStep: Codable {
      - parameter instructionsSpokenAlongStep: Instructions about the next step’s maneuver, optimized for speech synthesis.
      - parameter instructionsDisplayedAlongStep: Instructions about the next step’s maneuver, optimized for display in real time.
      */
-    public init(transportType: TransportType, maneuverLocation: CLLocationCoordinate2D, maneuverType: ManeuverType, maneuverDirection: ManeuverDirection? = nil, instructions: String, initialHeading: CLLocationDirection? = nil, finalHeading: CLLocationDirection? = nil, drivingSide: DrivingSide, exitCodes: [String]? = nil, exitNames: [String]? = nil, phoneticExitNames: [String]? = nil, distance: CLLocationDistance, expectedTravelTime: TimeInterval, typicalTravelTime: TimeInterval? = nil, names: [String]? = nil, phoneticNames: [String]? = nil, codes: [String]? = nil, destinationCodes: [String]? = nil, destinations: [String]? = nil, intersections: [Intersection]? = nil, speedLimitSignStandard: SignStandard? = nil, speedLimitUnit: UnitSpeed? = nil, instructionsSpokenAlongStep: [SpokenInstruction]? = nil, instructionsDisplayedAlongStep: [VisualInstructionBanner]? = nil, administrativeRegionIndicesByIntersection: [Int?]? = nil) {
+    public init(transportType: TransportType, maneuverLocation: CLLocationCoordinate2D, maneuverType: ManeuverType, maneuverDirection: ManeuverDirection? = nil, instructions: String, initialHeading: CLLocationDirection? = nil, finalHeading: CLLocationDirection? = nil, drivingSide: DrivingSide, exitCodes: [String]? = nil, exitNames: [String]? = nil, phoneticExitNames: [String]? = nil, distance: CLLocationDistance, expectedTravelTime: TimeInterval, typicalTravelTime: TimeInterval? = nil, names: [String]? = nil, phoneticNames: [String]? = nil, codes: [String]? = nil, destinationCodes: [String]? = nil, destinations: [String]? = nil, intersections: [Intersection]? = nil, speedLimitSignStandard: SignStandard? = nil, speedLimitUnit: UnitSpeed? = nil, instructionsSpokenAlongStep: [SpokenInstruction]? = nil, instructionsDisplayedAlongStep: [VisualInstructionBanner]? = nil, administrativeAreaContainerByIntersection: [Int?]? = nil) {
         self.transportType = transportType
         self.maneuverLocation = maneuverLocation
         self.maneuverType = maneuverType
@@ -485,7 +485,7 @@ open class RouteStep: Codable {
         self.speedLimitUnit = speedLimitUnit
         self.instructionsSpokenAlongStep = instructionsSpokenAlongStep
         self.instructionsDisplayedAlongStep = instructionsDisplayedAlongStep
-        self.administrativeRegionIndicesByIntersection = administrativeRegionIndicesByIntersection
+        self.administrativeAreaContainerByIntersection = administrativeAreaContainerByIntersection
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -517,7 +517,7 @@ open class RouteStep: Codable {
             var intersectionsContainer = container.nestedUnkeyedContainer(forKey: .intersections)
             try Intersection.encode(intersections: intersectionsToEncode,
                                     to: &intersectionsContainer,
-                                    administrativeRegionIndices: administrativeRegionIndicesByIntersection)
+                                    administrativeRegionIndices: administrativeAreaContainerByIntersection)
         }
         
         try container.encode(drivingSide, forKey: .drivingSide)
@@ -612,15 +612,14 @@ open class RouteStep: Codable {
         typicalTravelTime = try container.decodeIfPresent(TimeInterval.self, forKey: .typicalTravelTime)
         
         transportType = try container.decode(TransportType.self, forKey: .transportType)
-        
-        administrativeRegionIndicesByIntersection = try container.decodeIfPresent([AdministrativeAreaIndex].self,
+        administrativeAreaContainerByIntersection = try container.decodeIfPresent([AdministrativeAreaIndex].self,
                                                                                   forKey: .intersections)?.map { $0.administrativeRegionIndex }
         var rawIntersections = try container.decodeIfPresent([Intersection].self, forKey: .intersections)
         
         // Updating `Intersection.regionCode` since we removed it's `admin_index` for convenience
         if let administrativeRegions = administrativeRegions,
            rawIntersections != nil,
-           let rawAdminIndicies = administrativeRegionIndicesByIntersection {
+           let rawAdminIndicies = administrativeAreaContainerByIntersection {
             for index in 0..<rawIntersections!.count {
                 if let regionIndex = rawAdminIndicies[index],
                    administrativeRegions.count > regionIndex {
@@ -834,8 +833,10 @@ open class RouteStep: Codable {
      An array of `Administrative Regions` indicies for each `intersection` along current step.
      
      Array may be `nil` in case `intersections` data is not available. Array element may be `nil` if corresponding `intersection` has no `Administrative Region` assigned.
-     */
-    public let administrativeRegionIndicesByIntersection: [Int?]?
+     
+    - seealso: `Intersection.regionCode`
+    */
+    public let administrativeAreaContainerByIntersection: [Int?]?
 
     /**
      The sign design standard used for speed limit signs along the step.

--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -830,9 +830,9 @@ open class RouteStep: Codable {
     public let intersections: [Intersection]?
     
     /**
-     An array of `Administrative Regions` indicies for each `intersection` along current step.
-     
-     Array may be `nil` in case `intersections` data is not available. Array element may be `nil` if corresponding `intersection` has no `Administrative Region` assigned.
+     Each intersection’s administrative region index.
+          
+     This property is set to `nil` if the `intersections` property is `nil`. An individual array element may be `nil` if the corresponding `Intersection` instance has no administrative region assigned.
      
     - seealso: `Intersection.regionCode`, `RouteStep.regionCode(atStepIndex:, intersectionIndex:)`
     */

--- a/Tests/MapboxDirectionsTests/IntersectionTests.swift
+++ b/Tests/MapboxDirectionsTests/IntersectionTests.swift
@@ -66,7 +66,7 @@ class IntersectionTests: XCTestCase {
                          tunnelName: nil,
                          restStop: nil,
                          isUrban: nil,
-                         administrationRegionIndex: nil),
+                         administrativeRegionIndex: nil),
             Intersection(location: CLLocationCoordinate2D(latitude: 52.508022, longitude: 13.426688),
                          headings: [30.0, 120.0, 300.0],
                          approachIndex: 2,
@@ -79,7 +79,7 @@ class IntersectionTests: XCTestCase {
                          tunnelName: nil,
                          restStop: nil,
                          isUrban: nil,
-                         administrationRegionIndex: nil),
+                         administrativeRegionIndex: nil),
             Intersection(location: CLLocationCoordinate2D(latitude: 39.102483, longitude: -84.503956),
                          headings: [45, 135, 255],
                          approachIndex: 2,
@@ -92,7 +92,7 @@ class IntersectionTests: XCTestCase {
                          tunnelName: nil,
                          restStop: nil,
                          isUrban: nil,
-                         administrationRegionIndex: nil)
+                         administrativeRegionIndex: nil)
         ]
         
         let encoder = JSONEncoder()

--- a/Tests/MapboxDirectionsTests/IntersectionTests.swift
+++ b/Tests/MapboxDirectionsTests/IntersectionTests.swift
@@ -65,8 +65,7 @@ class IntersectionTests: XCTestCase {
                          tollCollection: nil,
                          tunnelName: nil,
                          restStop: nil,
-                         isUrban: nil,
-                         administrativeRegionIndex: nil),
+                         isUrban: nil),
             Intersection(location: CLLocationCoordinate2D(latitude: 52.508022, longitude: 13.426688),
                          headings: [30.0, 120.0, 300.0],
                          approachIndex: 2,
@@ -78,8 +77,7 @@ class IntersectionTests: XCTestCase {
                          tollCollection: nil,
                          tunnelName: nil,
                          restStop: nil,
-                         isUrban: nil,
-                         administrativeRegionIndex: nil),
+                         isUrban: nil),
             Intersection(location: CLLocationCoordinate2D(latitude: 39.102483, longitude: -84.503956),
                          headings: [45, 135, 255],
                          approachIndex: 2,
@@ -91,8 +89,7 @@ class IntersectionTests: XCTestCase {
                          tollCollection: nil,
                          tunnelName: nil,
                          restStop: nil,
-                         isUrban: nil,
-                         administrativeRegionIndex: nil)
+                         isUrban: nil)
         ]
         
         let encoder = JSONEncoder()


### PR DESCRIPTION
Resolves #477 

Added properties `Intersection.regionCode` and `RouteStep.administrativeRegionIndicesByIntersection`. Made `Intersection.administrativeRegionIndex` internal.

I was trying to remove `Intersection.administrativeRegionIndex` completely and this is the solution I ended up with. Would love to see a feedback on that approach.
This solution introduces some internal manipulations in order to encode and decode `Routes` correctly, while preserving individual `Intersection` codability. The issue I am seeing there is that such behavior might be implicit for users, and mu confuse why same `Incident` gets encoded and decoded differently when it's a part of a `RouteStep` and when it's not.