### PR TITLE
OHHTTPStubs v9.0.0

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 5.5
-github "linksmt/OHHTTPStubs" "563f48d3fab84ef04639649c770b00f4fa502cca"
+github "AliSoftware/OHHTTPStubs" ~> 9.0
 github "mapbox/mapbox-events-ios" ~> 0.10

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "5.9.0"
-github "linksmt/OHHTTPStubs" "563f48d3fab84ef04639649c770b00f4fa502cca"
+github "AliSoftware/OHHTTPStubs" "9.0.0"
 github "mapbox/mapbox-events-ios" "v0.10.5"
 github "mapbox/turf-swift" "v1.1.0"
 github "raphaelmor/Polyline" "v5.0.2"

--- a/Tests/MapboxDirectionsTests/AnnotationTests.swift
+++ b/Tests/MapboxDirectionsTests/AnnotationTests.swift
@@ -5,7 +5,7 @@ import OHHTTPStubs
 
 class AnnotationTests: XCTestCase {
     override func tearDown() {
-        OHHTTPStubs.removeAllStubs()
+        HTTPStubs.removeAllStubs()
         super.tearDown()
     }
     
@@ -25,7 +25,7 @@ class AnnotationTests: XCTestCase {
         stub(condition: isHost("api.mapbox.com")
                 && containsQueryParams(queryParams)) { _ in
             let path = Bundle.module.path(forResource: "annotation", ofType: "json")
-            return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
+            return HTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
         
         let options = RouteOptions(coordinates: [

--- a/Tests/MapboxDirectionsTests/DirectionsCredentialsTests.swift
+++ b/Tests/MapboxDirectionsTests/DirectionsCredentialsTests.swift
@@ -1,6 +1,4 @@
 import XCTest
-#if !SWIFT_PACKAGE
-import OHHTTPStubs
 @testable import MapboxDirections
 
 class DirectionsCredentialsTests: XCTestCase {
@@ -18,4 +16,3 @@ class DirectionsCredentialsTests: XCTestCase {
         XCTAssertEqual(credentials.host, host)
     }
 }
-#endif

--- a/Tests/MapboxDirectionsTests/DirectionsTests.swift
+++ b/Tests/MapboxDirectionsTests/DirectionsTests.swift
@@ -39,7 +39,7 @@ class DirectionsTests: XCTestCase {
         NSTimeZone.default = TimeZone(secondsFromGMT: 0)!
     }
     override func tearDown() {
-        OHHTTPStubs.removeAllStubs()
+        HTTPStubs.removeAllStubs()
         super.tearDown()
     }
     
@@ -86,10 +86,10 @@ class DirectionsTests: XCTestCase {
     }
     
     func testKnownBadResponse() {
-        OHHTTPStubs.stubRequests(passingTest: { (request) -> Bool in
+        HTTPStubs.stubRequests(passingTest: { (request) -> Bool in
             return request.url!.absoluteString.contains("https://api.mapbox.com/directions")
-        }) { (_) -> OHHTTPStubsResponse in
-            return OHHTTPStubsResponse(data: BadResponse.data(using: .utf8)!, statusCode: 413, headers: ["Content-Type" : "text/html"])
+        }) { (_) -> HTTPStubsResponse in
+            return HTTPStubsResponse(data: BadResponse.data(using: .utf8)!, statusCode: 413, headers: ["Content-Type" : "text/html"])
         }
         let expectation = self.expectation(description: "Async callback")
         let one = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0))
@@ -112,10 +112,10 @@ class DirectionsTests: XCTestCase {
     
     func testUnknownBadResponse() {
         let message = "Enhance your calm, John Spartan."
-        OHHTTPStubs.stubRequests(passingTest: { (request) -> Bool in
+        HTTPStubs.stubRequests(passingTest: { (request) -> Bool in
             return request.url!.absoluteString.contains("https://api.mapbox.com/directions")
-        }) { (_) -> OHHTTPStubsResponse in
-            return OHHTTPStubsResponse(data: message.data(using: .utf8)!, statusCode: 420, headers: ["Content-Type" : "text/plain"])
+        }) { (_) -> HTTPStubsResponse in
+            return HTTPStubsResponse(data: message.data(using: .utf8)!, statusCode: 420, headers: ["Content-Type" : "text/plain"])
         }
         let expectation = self.expectation(description: "Async callback")
         let one = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0))
@@ -158,10 +158,10 @@ class DirectionsTests: XCTestCase {
     func testDownNetwork() {
         let notConnected = NSError(domain: NSURLErrorDomain, code: URLError.notConnectedToInternet.rawValue) as! URLError
         
-        OHHTTPStubs.stubRequests(passingTest: { (request) -> Bool in
+        HTTPStubs.stubRequests(passingTest: { (request) -> Bool in
             return request.url!.absoluteString.contains("https://api.mapbox.com/directions")
-        }) { (_) -> OHHTTPStubsResponse in
-            return OHHTTPStubsResponse(error: notConnected)
+        }) { (_) -> HTTPStubsResponse in
+            return HTTPStubsResponse(error: notConnected)
         }
         
         let expectation = self.expectation(description: "Async callback")

--- a/Tests/MapboxDirectionsTests/MatchTests.swift
+++ b/Tests/MapboxDirectionsTests/MatchTests.swift
@@ -12,7 +12,7 @@ import OHHTTPStubs
 class MatchTests: XCTestCase {
     override func tearDown() {
         #if !SWIFT_PACKAGE
-        OHHTTPStubs.removeAllStubs()
+        HTTPStubs.removeAllStubs()
         #endif
         super.tearDown()
     }
@@ -32,7 +32,7 @@ class MatchTests: XCTestCase {
             && isMethodGET()
             && pathStartsWith("/matching/v5/mapbox/driving")) { _ in
                 let path = Bundle.module.path(forResource: "match", ofType: "json")
-                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
+                return HTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
         
         var response: MapMatchingResponse!
@@ -121,7 +121,7 @@ class MatchTests: XCTestCase {
             && isMethodGET()
             && pathStartsWith("/matching/v5/mapbox/driving")) { _ in
                 let path = Bundle.module.path(forResource: "null-tracepoint", ofType: "json")
-                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
+                return HTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
         
         var response: MapMatchingResponse!

--- a/Tests/MapboxDirectionsTests/OfflineDirectionsTests.swift
+++ b/Tests/MapboxDirectionsTests/OfflineDirectionsTests.swift
@@ -22,7 +22,7 @@ class OfflineDirectionsTests: XCTestCase {
             let filePath = URL(fileURLWithPath: path!)
             let data = try! Data(contentsOf: filePath)
             let jsonObject = try! JSONSerialization.jsonObject(with: data, options: [])
-            return OHHTTPStubsResponse(jsonObject: jsonObject, statusCode: 200, headers: ["Content-Type": "application/json"])
+            return HTTPStubsResponse(jsonObject: jsonObject, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
         
         directions.fetchAvailableOfflineVersions { (versions, error) in
@@ -30,7 +30,7 @@ class OfflineDirectionsTests: XCTestCase {
             XCTAssertEqual(versions!.first!, "2018-10-16")
             
             versionsExpectation.fulfill()
-            OHHTTPStubs.removeStub(apiStub)
+            HTTPStubs.removeStub(apiStub)
         }
         
         wait(for: [versionsExpectation], timeout: 2)
@@ -57,7 +57,7 @@ class OfflineDirectionsTests: XCTestCase {
             headers["Accept-Ranges"] = "bytes"
             headers["Content-Disposition"] = "attachment; filename=\"\(version).tar\""
             
-            return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: headers)
+            return HTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: headers)
         }
         
         directions.downloadTiles(in: bounds, version: version, completionHandler: { (url, response, error) in
@@ -66,7 +66,7 @@ class OfflineDirectionsTests: XCTestCase {
             XCTAssertNil(error)
             
             downloadExpectation.fulfill()
-            OHHTTPStubs.removeStub(apiStub)
+            HTTPStubs.removeStub(apiStub)
         })
         
         wait(for: [downloadExpectation], timeout: 60)

--- a/Tests/MapboxDirectionsTests/RoutableMatchTests.swift
+++ b/Tests/MapboxDirectionsTests/RoutableMatchTests.swift
@@ -5,7 +5,7 @@ import OHHTTPStubs
 
 class RoutableMatchTest: XCTestCase {
     override func tearDown() {
-        OHHTTPStubs.removeAllStubs()
+        HTTPStubs.removeAllStubs()
         super.tearDown()
     }
     
@@ -23,7 +23,7 @@ class RoutableMatchTest: XCTestCase {
             && isMethodGET()
             && pathStartsWith("/matching/v5/mapbox/driving")) { _ in
                 let path = Bundle(for: type(of: self)).path(forResource: "match-polyline6", ofType: "json")
-                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
+                return HTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
         
         var routeResponse: RouteResponse!

--- a/Tests/MapboxDirectionsTests/RouteRefreshTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteRefreshTests.swift
@@ -16,7 +16,7 @@ class RouteRefreshTests: XCTestCase {
             && isMethodGET()
             && pathStartsWith("/directions/v5/mapbox/driving-traffic")) { _ in
                 let path = Bundle(for: type(of: self)).path(forResource: "routeRefreshRoute", ofType: "json")
-                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
+                return HTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
         
         stub(condition: isHost("api.mapbox.com")
@@ -25,16 +25,16 @@ class RouteRefreshTests: XCTestCase {
                 switch Int($0.url!.lastPathComponent)! {
                 case 0...1:
                     let path = Bundle(for: type(of: self)).path(forResource: "routeRefreshResponse", ofType: "json")
-                    return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
+                    return HTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
                 default:
                     let path = Bundle(for: type(of: self)).path(forResource: "incorrectRouteRefreshResponse", ofType: "json")
-                    return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 422, headers: ["Content-Type": "application/json"])
+                    return HTTPStubsResponse(fileAtPath: path!, statusCode: 422, headers: ["Content-Type": "application/json"])
                 }
         }
     }
 
     override func tearDown() {
-        OHHTTPStubs.removeAllStubs()
+        HTTPStubs.removeAllStubs()
         super.tearDown()
     }
     

--- a/Tests/MapboxDirectionsTests/V5Tests.swift
+++ b/Tests/MapboxDirectionsTests/V5Tests.swift
@@ -6,7 +6,7 @@ import Polyline
 
 class V5Tests: XCTestCase {
     override func tearDown() {
-        OHHTTPStubs.removeAllStubs()
+        HTTPStubs.removeAllStubs()
         super.tearDown()
     }
     
@@ -31,7 +31,7 @@ class V5Tests: XCTestCase {
                 let data = try! Data(contentsOf: filePath, options: [])
                 let jsonObject = try! JSONSerialization.jsonObject(with: data, options: [])
                 let transformedData = transformer?(jsonObject as! JSONDictionary) ?? jsonObject
-                return OHHTTPStubsResponse(jsonObject: transformedData, statusCode: 200, headers: ["Content-Type": "application/json"])
+                return HTTPStubsResponse(jsonObject: transformedData, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
         
         let options = RouteOptions(coordinates: [
@@ -227,7 +227,7 @@ class V5Tests: XCTestCase {
                 let filePath = URL(fileURLWithPath: path!)
                 let data = try! Data(contentsOf: filePath, options: [])
                 let jsonObject = try! JSONSerialization.jsonObject(with: data, options: [])
-                return OHHTTPStubsResponse(jsonObject: jsonObject, statusCode: 200, headers: ["Content-Type": "application/json"])
+                return HTTPStubsResponse(jsonObject: jsonObject, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
         
         let waypoints = [

--- a/Tests/MapboxDirectionsTests/VisualInstructionTests.swift
+++ b/Tests/MapboxDirectionsTests/VisualInstructionTests.swift
@@ -5,7 +5,7 @@ import OHHTTPStubs
 
 class VisualInstructionsTests: XCTestCase {
     override func tearDown() {
-        OHHTTPStubs.removeAllStubs()
+        HTTPStubs.removeAllStubs()
         super.tearDown()
     }
     
@@ -104,7 +104,7 @@ class VisualInstructionsTests: XCTestCase {
         stub(condition: isHost("api.mapbox.com")
             && containsQueryParams(queryParams)) { _ in
                 let path = Bundle(for: type(of: self)).path(forResource: "instructions", ofType: "json")
-                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
+                return HTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
         
         let startWaypoint = Waypoint(location:  CLLocation(latitude: 37.780602, longitude: -122.431373), heading: nil, name: "the hotel")
@@ -203,7 +203,7 @@ class VisualInstructionsTests: XCTestCase {
         
         stub(condition: isHost("api.mapbox.com") && containsQueryParams(queryParams)) { _ in
             let path = Bundle(for: type(of: self)).path(forResource: "subLaneInstructions", ofType: "json")
-            return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
+            return HTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
         
         let startWaypoint =  Waypoint(coordinate: CLLocationCoordinate2D(latitude: 39.132063, longitude: -84.531074))
@@ -278,7 +278,7 @@ class VisualInstructionsTests: XCTestCase {
         
         stub(condition: isHost("api.mapbox.com") && containsQueryParams(queryParams)) { _ in
             let path = Bundle(for: type(of: self)).path(forResource: "subVisualInstructions", ofType: "json")
-            return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
+            return HTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
         
         let startWaypoint =  Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.775469, longitude: -122.449158))


### PR DESCRIPTION
Upgraded to OHHTTPStubs v9.0.0. Not seeing any ill effects on watchOS from eschewing AliSoftware/OHHTTPStubs#286, since we don’t have a watchOS test target anyways (#496).

/ref #494
/cc @mapbox/navigation-ios @frederoni