### PR TITLE
Add CaseIterable protocol conformance in CongestionLevel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added support for building and running on any Linux distribution supported by Swift. ([#488](https://github.com/mapbox/mapbox-directions-swift/pull/488))
 * Added the `MapboxDirectionsCLI` command line tool that round-trips Mapbox Directions API responses between JSON format and Swift model objects. ([#469](https://github.com/mapbox/mapbox-directions-swift/pull/469))
+* The `CongestionLevel` enumeration now conforms to the `CaseIterable` protocol. ([#500](https://github.com/mapbox/mapbox-directions-swift/pull/500))
 
 ## v1.1.0
 

--- a/Sources/MapboxDirections/Congestion.swift
+++ b/Sources/MapboxDirections/Congestion.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  A `CongestionLevel` indicates the level of traffic congestion along a road segment relative to the normal flow of traffic along that segment. You can color-code a route line according to the congestion level along each segment of the route.
  */
-public enum CongestionLevel: String, Codable {
+public enum CongestionLevel: String, Codable, CaseIterable {
     /**
      There is not enough data to determine the level of congestion along the road segment.
      */


### PR DESCRIPTION
`CaseIterable` protocol conformance was added to `CongestionLevel` to be able to generate random congestion levels in https://github.com/mapbox/navigation-ios-examples/pull/83.