### PR TITLE
Linux SPM Build error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - image: swift:5.3
     steps:
       - checkout
-      - run: swift build
+      - run: swift build --jobs=1
       - run: swift test
 
   spm-job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
       - image: swift:5.3
     steps:
       - checkout
+      # Limiting number of parallel jobs to avoid build crash bug.
       - run: swift build --jobs=1
       - run: swift test
 


### PR DESCRIPTION
Resolves #498 
I tried to find the core reason of the issue, but did not find any information. Apparently there is some threading bug in compiling, but I have no means to prove it.

What I've found during the investigation:
* Resetting build cache (via `swift package reset`) causes next `swift build` to fail)
* The usual build runs correctly if started for the second time (via `ssh`)
* Console output and error outputs are clean
* Neither `--verbose` nor `--sanitize` options provide more information for debugging

All the above points towards compiler bug, and current solution is just a workaround for the issue.