### PR TITLE
Toll Collection encoding fix

### DIFF
--- a/Sources/MapboxDirections/Intersection.swift
+++ b/Sources/MapboxDirections/Intersection.swift
@@ -259,7 +259,7 @@ extension Intersection: Codable {
             try container.encode(classes, forKey: .outletRoadClasses)
         }
 
-        if let tolls = tollCollection?.type {
+        if let tolls = tollCollection {
             try container.encode(tolls, forKey: .tollCollection)
         }
 

--- a/Tests/MapboxDirectionsTests/IntersectionTests.swift
+++ b/Tests/MapboxDirectionsTests/IntersectionTests.swift
@@ -19,6 +19,7 @@ class IntersectionTests: XCTestCase {
                 "mapbox_streets_v8": [
                     "class": "street_limited"
                 ],
+                "toll_collection": ["type": "toll_booth"],
             ],
             [
                 "out": 1,
@@ -66,7 +67,7 @@ class IntersectionTests: XCTestCase {
                          approachLanes: nil,
                          usableApproachLanes: nil,
                          outletRoadClasses: [.toll, .restricted],
-                         tollCollection: nil,
+                         tollCollection: TollCollection(type: .booth),
                          tunnelName: nil,
                          restStop: nil,
                          isUrban: nil,


### PR DESCRIPTION
Fixes ToolCollection encoding as a part of Route object.

There is inconsistency in decoding and encoding Route Object when it includes a Toll Collection.