### PR TITLE
Add fallback access token.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 
+* To gain access to the Mapbox Directions and Map Matching APIs, set `MBXAccessToken` in your Info.plist. `MGLMapboxAccessToken` is still supported but is now deprecated. ([#522](https://github.com/mapbox/mapbox-directions-swift/pull/522))
 * This library requires Turf v2.0.0-alpha.2. ([#517](https://github.com/mapbox/mapbox-directions-swift/pull/517))
 * This library does not support tvOS, watchOS, or Linux. Support for these platforms will be restored before the final release. ([#517](https://github.com/mapbox/mapbox-directions-swift/pull/517))
 * The `Incident.impact` property is now an `Incident.Impact` value instead of a string. ([#519](https://github.com/mapbox/mapbox-directions-swift/pull/519))

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ v0.30.0 is the last release of MapboxDirections.swift that supports a minimum de
 
 **[API reference](https://docs.mapbox.com/ios/api/directions/)**
 
-You’ll need a [Mapbox access token](https://docs.mapbox.com/api/#access-tokens-and-token-scopes) in order to use the API. If you’re already using the [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/), Mapbox Directions automatically recognizes your access token, as long as you’ve placed it in the `MGLMapboxAccessToken` key of your application’s Info.plist file.
+You’ll need a [Mapbox access token](https://docs.mapbox.com/api/#access-tokens-and-token-scopes) in order to use the API. If you’re already using the [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/), Mapbox Directions automatically recognizes your access token, as long as you’ve placed it in the `MBXAccessToken` key of your application’s Info.plist file.
 
 The examples below are each provided in Swift (denoted with `main.swift`), For further details, see the [Mapbox Directions for Swift API reference](https://docs.mapbox.com/ios/api/directions/).
 
@@ -78,7 +78,7 @@ import MapboxDirections
 let directions = Directions(credentials: DirectionsCredentials(accessToken: "<#your access token#>"))
 ```
 
-Alternatively, you can place your access token in the `MGLMapboxAccessToken` key of your application’s Info.plist file, then use the shared directions object:
+Alternatively, you can place your access token in the `MBXAccessToken` key of your application’s Info.plist file, then use the shared directions object:
 
 ```swift
 // main.swift

--- a/Sources/MapboxDirections/Directions.swift
+++ b/Sources/MapboxDirections/Directions.swift
@@ -110,7 +110,7 @@ open class Directions: NSObject {
     /**
      The shared directions object.
      
-     To use this object, a Mapbox [access token](https://docs.mapbox.com/help/glossary/access-token/) should be specified in the `MGLMapboxAccessToken` key in the main application bundle’s Info.plist.
+     To use this object, a Mapbox [access token](https://docs.mapbox.com/help/glossary/access-token/) should be specified in the `MBXAccessToken` key in the main application bundle’s Info.plist.
      */
     public static let shared = Directions()
 

--- a/Sources/MapboxDirections/DirectionsCredentials.swift
+++ b/Sources/MapboxDirections/DirectionsCredentials.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 /// The Mapbox access token specified in the main application bundle’s Info.plist.
-let defaultAccessToken = Bundle.main.object(forInfoDictionaryKey: "MGLMapboxAccessToken") as? String
+let defaultAccessToken = Bundle.main.object(forInfoDictionaryKey: "MBXAccessToken") as? String
+let fallbackAccessToken = Bundle.main.object(forInfoDictionaryKey: "MGLMapboxAccessToken") as? String
 let defaultApiEndPointURLString = Bundle.main.object(forInfoDictionaryKey: "MGLMapboxAPIBaseURL") as? String
 
 public struct DirectionsCredentials: Equatable {
@@ -36,7 +37,7 @@ public struct DirectionsCredentials: Equatable {
      - parameter host: Optional. A parameter to pass a custom host. If `nil` is provided, the SDK will attempt to find a host from your app's `info.plist`, and barring that will default to  `https://api.mapbox.com`.
      */
     public init(accessToken token: String? = nil, host: URL? = nil) {
-        let accessToken = token ?? defaultAccessToken
+        let accessToken = token ?? defaultAccessToken ?? fallbackAccessToken
         
         precondition(accessToken != nil && !accessToken!.isEmpty, "A Mapbox access token is required. Go to <https://account.mapbox.com/access-tokens/>. In Info.plist, set the MGLMapboxAccessToken key to your access token, or use the Directions(accessToken:host:) initializer.")
         self.accessToken = accessToken

--- a/Sources/MapboxDirections/DirectionsCredentials.swift
+++ b/Sources/MapboxDirections/DirectionsCredentials.swift
@@ -1,8 +1,9 @@
 import Foundation
 
 /// The Mapbox access token specified in the main application bundle’s Info.plist.
-let defaultAccessToken = Bundle.main.object(forInfoDictionaryKey: "MBXAccessToken") as? String
-let fallbackAccessToken = Bundle.main.object(forInfoDictionaryKey: "MGLMapboxAccessToken") as? String
+let defaultAccessToken =
+    Bundle.main.object(forInfoDictionaryKey: "MBXAccessToken") as? String ??
+    Bundle.main.object(forInfoDictionaryKey: "MGLMapboxAccessToken") as? String
 let defaultApiEndPointURLString = Bundle.main.object(forInfoDictionaryKey: "MGLMapboxAPIBaseURL") as? String
 
 public struct DirectionsCredentials: Equatable {
@@ -37,9 +38,9 @@ public struct DirectionsCredentials: Equatable {
      - parameter host: Optional. A parameter to pass a custom host. If `nil` is provided, the SDK will attempt to find a host from your app's `info.plist`, and barring that will default to  `https://api.mapbox.com`.
      */
     public init(accessToken token: String? = nil, host: URL? = nil) {
-        let accessToken = token ?? defaultAccessToken ?? fallbackAccessToken
+        let accessToken = token ?? defaultAccessToken
         
-        precondition(accessToken != nil && !accessToken!.isEmpty, "A Mapbox access token is required. Go to <https://account.mapbox.com/access-tokens/>. In Info.plist, set the MGLMapboxAccessToken key to your access token, or use the Directions(accessToken:host:) initializer.")
+        precondition(accessToken != nil && !accessToken!.isEmpty, "A Mapbox access token is required. Go to <https://account.mapbox.com/access-tokens/>. In Info.plist, set the MBXAccessToken key to your access token, or use the Directions(accessToken:host:) initializer.")
         self.accessToken = accessToken
         if let host = host {
             self.host = host

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -28,7 +28,7 @@ Then `import MapboxDirections`.
 
 ## Configuration
 
-You’ll need a [Mapbox access token](https://docs.mapbox.com/api/#access-tokens-and-token-scopes) in order to use the API. If you’re already using the [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/), Mapbox Directions automatically recognizes your access token, as long as you’ve placed it in the `MGLMapboxAccessToken` key of your application’s Info.plist file.
+You’ll need a [Mapbox access token](https://docs.mapbox.com/api/#access-tokens-and-token-scopes) in order to use the API. If you’re already using the [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/), Mapbox Directions automatically recognizes your access token, as long as you’ve placed it in the `MBXAccessToken` key of your application’s Info.plist file.
 
 ## Starting points
 


### PR DESCRIPTION
Add fallback access token and use `MBXAccessToken` as default access token.