### PR TITLE
Fix VisualInstruction.component.lane type mismatch

### DIFF
--- a/Sources/MapboxDirections/VisualInstructionComponent.swift
+++ b/Sources/MapboxDirections/VisualInstructionComponent.swift
@@ -197,7 +197,7 @@ extension VisualInstruction.Component: Codable {
         case imageURL
         case directions
         case isActive = "active"
-        case activeDirection = "active_direction"
+        case active_direction
     }
     
     enum Kind: String, Codable {
@@ -217,7 +217,10 @@ extension VisualInstruction.Component: Codable {
         if kind == .lane {
             let indications = try container.decode(LaneIndication.self, forKey: .directions)
             let isUsable = try container.decode(Bool.self, forKey: .isActive)
-            let preferredDirection = try container.decodeIfPresent(LaneIndication.self, forKey: .activeDirection)
+            var preferredDirection: LaneIndication? = nil
+            if let preferredDirectionDescription = try container.decodeIfPresent(String.self, forKey: .active_direction) {
+                preferredDirection = LaneIndication(descriptions: [preferredDirectionDescription])
+            }
             self = .lane(indications: indications, isUsable: isUsable, preferredDirection: preferredDirection)
             return
         }
@@ -281,7 +284,7 @@ extension VisualInstruction.Component: Codable {
             textRepresentation = .init(text: "", abbreviation: nil, abbreviationPriority: nil)
             try container.encode(indications, forKey: .directions)
             try container.encode(isUsable, forKey: .isActive)
-            try container.encodeIfPresent(preferredDirection, forKey: .activeDirection)
+            try container.encodeIfPresent(preferredDirection?.descriptions.first, forKey: .active_direction)
         case .guidanceView(let image, let alternativeText):
             try container.encode(Kind.guidanceView, forKey: .kind)
             textRepresentation = alternativeText

--- a/Sources/MapboxDirections/VisualInstructionComponent.swift
+++ b/Sources/MapboxDirections/VisualInstructionComponent.swift
@@ -197,7 +197,7 @@ extension VisualInstruction.Component: Codable {
         case imageURL
         case directions
         case isActive = "active"
-        case active_direction
+        case activeDirection = "active_direction"
     }
     
     enum Kind: String, Codable {
@@ -218,7 +218,7 @@ extension VisualInstruction.Component: Codable {
             let indications = try container.decode(LaneIndication.self, forKey: .directions)
             let isUsable = try container.decode(Bool.self, forKey: .isActive)
             var preferredDirection: LaneIndication? = nil
-            if let preferredDirectionDescription = try container.decodeIfPresent(String.self, forKey: .active_direction) {
+            if let preferredDirectionDescription = try container.decodeIfPresent(String.self, forKey: .activeDirection) {
                 preferredDirection = LaneIndication(descriptions: [preferredDirectionDescription])
             }
             self = .lane(indications: indications, isUsable: isUsable, preferredDirection: preferredDirection)
@@ -284,7 +284,7 @@ extension VisualInstruction.Component: Codable {
             textRepresentation = .init(text: "", abbreviation: nil, abbreviationPriority: nil)
             try container.encode(indications, forKey: .directions)
             try container.encode(isUsable, forKey: .isActive)
-            try container.encodeIfPresent(preferredDirection?.descriptions.first, forKey: .active_direction)
+            try container.encodeIfPresent(preferredDirection?.descriptions.first, forKey: .activeDirection)
         case .guidanceView(let image, let alternativeText):
             try container.encode(Kind.guidanceView, forKey: .kind)
             textRepresentation = alternativeText

--- a/Tests/MapboxDirectionsTests/VisualInstructionComponentTests.swift
+++ b/Tests/MapboxDirectionsTests/VisualInstructionComponentTests.swift
@@ -69,7 +69,7 @@ class VisualInstructionComponentTests: XCTestCase {
             "type": "lane",
             "active": true,
             "directions": ["right", "straight"],
-            "active_direction": ["right"],
+            "active_direction": "right",
         ]
         let componentData = try! JSONSerialization.data(withJSONObject: componentJSON, options: [])
         var component: VisualInstruction.Component?


### PR DESCRIPTION
This PR fixes a type mismatch in the encoding/decoding of the `VisualInstruction.Component.lane.preferredDirection` enumeration case as well as the relevant tests.
