### PR TITLE
Preferred lane direction is now a ManeuverDirection

### DIFF
--- a/Sources/MapboxDirections/Intersection.swift
+++ b/Sources/MapboxDirections/Intersection.swift
@@ -267,11 +267,7 @@ extension Intersection: Codable {
             lanes = approachLanes.map { Lane(indications: $0) }
             for i in usableApproachLanes {
                 lanes![i].isValid = true
-//                if lanes![i].indications.contains(usableLaneIndication){
-//                    lanes![i].validIndication = usableLaneIndication
-//                }
-//                let usable = LaneIndication(descriptions: [usableLaneIndication.rawValue])
-                if lanes![i].indications.contains(LaneIndication(descriptions: [usableLaneIndication.rawValue])!) {
+                if lanes![i].indications.descriptions.contains(usableLaneIndication.rawValue) {
                     lanes![i].validIndication = usableLaneIndication
                 }
             }
@@ -323,9 +319,11 @@ extension Intersection: Codable {
             approachLanes = lanes.map { $0.indications }
             usableApproachLanes = lanes.indices { $0.isValid }
             preferredApproachLanes = lanes.indices { ($0.isActive ?? false) }
-            usableLaneIndication = lanes.compactMap { $0.validIndication }[0]
-//            let usableIndications = lanes.compactMap { $0.validIndication }
-//            usableLaneIndication = usableIndications.reduce(ManeuverDirection(rawValue: "none")) { $0.union($1) }
+            if Set(lanes.compactMap { $0.validIndication}).count > 1 {
+                let context = EncodingError.Context(codingPath: decoder.codingPath, debugDescription: "Inconsistent valid indications.")
+                throw EncodingError.invalidValue(Set(lanes.compactMap { $0.validIndication}).count, context)
+            }
+            usableLaneIndication = lanes.compactMap { $0.validIndication }.first ?? ManeuverDirection.none
         } else {
             approachLanes = nil
             usableApproachLanes = nil

--- a/Sources/MapboxDirections/Intersection.swift
+++ b/Sources/MapboxDirections/Intersection.swift
@@ -325,7 +325,7 @@ extension Intersection: Codable {
                 let context = EncodingError.Context(codingPath: decoder.codingPath, debugDescription: "Inconsistent valid indications.")
                 throw EncodingError.invalidValue(validIndications, context)
             }
-            usableLaneIndication = lanes.compactMap { $0.validIndication }.first
+            usableLaneIndication = validIndications.first
         } else {
             approachLanes = nil
             usableApproachLanes = nil

--- a/Sources/MapboxDirections/Intersection.swift
+++ b/Sources/MapboxDirections/Intersection.swift
@@ -264,7 +264,6 @@ extension Intersection: Codable {
         if let approachLanes = approachLanes,
             let usableApproachLanes = usableApproachLanes,
             let preferredApproachLanes = preferredApproachLanes
-//            let usableLaneIndication = usableLaneIndication
         {
             lanes = approachLanes.map { Lane(indications: $0) }
             for i in usableApproachLanes {
@@ -326,10 +325,7 @@ extension Intersection: Codable {
                 let context = EncodingError.Context(codingPath: decoder.codingPath, debugDescription: "Inconsistent valid indications.")
                 throw EncodingError.invalidValue(validIndications, context)
             }
-//            let usableIndications = lanes.compactMap { $0.validIndication }
-//            usableLaneIndication = usableIndications.reduce(LaneIndication(rawValue: 0)) { $0.union($1) }
-//            let blah = validIndications.reduce(ManeuverDirection(rawValue: "none")) { $0 }
-            usableLaneIndication = lanes.compactMap { $0.validIndication }.first ?? ManeuverDirection(rawValue: "none")
+            usableLaneIndication = lanes.compactMap { $0.validIndication }.first
         } else {
             approachLanes = nil
             usableApproachLanes = nil

--- a/Sources/MapboxDirections/Intersection.swift
+++ b/Sources/MapboxDirections/Intersection.swift
@@ -15,7 +15,7 @@ public struct Intersection {
                 approachLanes: [LaneIndication]?,
                 usableApproachLanes: IndexSet?,
                 preferredApproachLanes: IndexSet?,
-                usableLaneIndication: LaneIndication?,
+                usableLaneIndication: ManeuverDirection?,
                 outletRoadClasses: RoadClasses? = nil,
                 tollCollection: TollCollection? = nil,
                 tunnelName: String? = nil,
@@ -165,7 +165,7 @@ public struct Intersection {
      
      If no lane information is available for the intersection, this property’s value is `nil`
      */
-    public let usableLaneIndication: LaneIndication?
+    public let usableLaneIndication: ManeuverDirection?
 }
 
 extension Intersection: Codable {
@@ -267,7 +267,11 @@ extension Intersection: Codable {
             lanes = approachLanes.map { Lane(indications: $0) }
             for i in usableApproachLanes {
                 lanes![i].isValid = true
-                if lanes![i].indications.contains(usableLaneIndication){
+//                if lanes![i].indications.contains(usableLaneIndication){
+//                    lanes![i].validIndication = usableLaneIndication
+//                }
+//                let usable = LaneIndication(descriptions: [usableLaneIndication.rawValue])
+                if lanes![i].indications.contains(LaneIndication(descriptions: [usableLaneIndication.rawValue])!) {
                     lanes![i].validIndication = usableLaneIndication
                 }
             }
@@ -319,8 +323,9 @@ extension Intersection: Codable {
             approachLanes = lanes.map { $0.indications }
             usableApproachLanes = lanes.indices { $0.isValid }
             preferredApproachLanes = lanes.indices { ($0.isActive ?? false) }
-            let usableIndications = lanes.compactMap { $0.validIndication }
-            usableLaneIndication = usableIndications.reduce(LaneIndication(rawValue: 0)) { $0.union($1) }
+            usableLaneIndication = lanes.compactMap { $0.validIndication }[0]
+//            let usableIndications = lanes.compactMap { $0.validIndication }
+//            usableLaneIndication = usableIndications.reduce(ManeuverDirection(rawValue: "none")) { $0.union($1) }
         } else {
             approachLanes = nil
             usableApproachLanes = nil

--- a/Sources/MapboxDirections/Intersection.swift
+++ b/Sources/MapboxDirections/Intersection.swift
@@ -260,15 +260,17 @@ extension Intersection: Codable {
         try container.encode(outletArray, forKey: .outletIndexes)
         
         var lanes: [Lane]?
+        print("lanes: \(String(describing: lanes))")
         if let approachLanes = approachLanes,
             let usableApproachLanes = usableApproachLanes,
-            let preferredApproachLanes = preferredApproachLanes,
-            let usableLaneIndication = usableLaneIndication {
+            let preferredApproachLanes = preferredApproachLanes
+//            let usableLaneIndication = usableLaneIndication
+        {
             lanes = approachLanes.map { Lane(indications: $0) }
             for i in usableApproachLanes {
                 lanes![i].isValid = true
-                if lanes![i].indications.descriptions.contains(usableLaneIndication.rawValue) {
-                    lanes![i].validIndication = usableLaneIndication
+                if usableLaneIndication != nil && lanes![i].indications.descriptions.contains(usableLaneIndication!.rawValue) {
+                        lanes![i].validIndication = usableLaneIndication
                 }
             }
             for j in preferredApproachLanes {
@@ -319,11 +321,15 @@ extension Intersection: Codable {
             approachLanes = lanes.map { $0.indications }
             usableApproachLanes = lanes.indices { $0.isValid }
             preferredApproachLanes = lanes.indices { ($0.isActive ?? false) }
-            if Set(lanes.compactMap { $0.validIndication}).count > 1 {
+            let validIndications = lanes.compactMap { $0.validIndication}
+            if Set(validIndications).count > 1 {
                 let context = EncodingError.Context(codingPath: decoder.codingPath, debugDescription: "Inconsistent valid indications.")
-                throw EncodingError.invalidValue(Set(lanes.compactMap { $0.validIndication}).count, context)
+                throw EncodingError.invalidValue(validIndications, context)
             }
-            usableLaneIndication = lanes.compactMap { $0.validIndication }.first ?? ManeuverDirection.none
+//            let usableIndications = lanes.compactMap { $0.validIndication }
+//            usableLaneIndication = usableIndications.reduce(LaneIndication(rawValue: 0)) { $0.union($1) }
+//            let blah = validIndications.reduce(ManeuverDirection(rawValue: "none")) { $0 }
+            usableLaneIndication = lanes.compactMap { $0.validIndication }.first ?? ManeuverDirection(rawValue: "none")
         } else {
             approachLanes = nil
             usableApproachLanes = nil

--- a/Sources/MapboxDirections/Lane.swift
+++ b/Sources/MapboxDirections/Lane.swift
@@ -54,9 +54,6 @@ extension Lane: Codable {
         indications = try container.decode(LaneIndication.self, forKey: .indications)
         isValid = try container.decode(Bool.self, forKey: .valid)
         isActive = try container.decodeIfPresent(Bool.self, forKey: .active)
-//        if let validIndicationDescription = try container.decodeIfPresent(String.self, forKey: .preferred) {
-//            validIndication = LaneIndication(descriptions: [validIndicationDescription])
-//        }
         validIndication = try container.decodeIfPresent(ManeuverDirection.self, forKey: .preferred)
     }
 }

--- a/Sources/MapboxDirections/Lane.swift
+++ b/Sources/MapboxDirections/Lane.swift
@@ -23,9 +23,9 @@ struct Lane: Equatable {
     /**
      Which of the `indications` is applicable to the current route, when there is more than one
      */
-    var validIndication: LaneIndication?
+    var validIndication: ManeuverDirection?
     
-    init(indications: LaneIndication, valid: Bool = false, active: Bool? = false, preferred: LaneIndication? = nil) {
+    init(indications: LaneIndication, valid: Bool = false, active: Bool? = false, preferred: ManeuverDirection? = nil) {
         self.indications = indications
         self.isValid = valid
         self.isActive = active
@@ -46,7 +46,7 @@ extension Lane: Codable {
         try container.encode(indications, forKey: .indications)
         try container.encode(isValid, forKey: .valid)
         try container.encodeIfPresent(isActive, forKey: .active)
-        try container.encodeIfPresent(validIndication?.descriptions.first, forKey: .preferred)
+        try container.encodeIfPresent(validIndication, forKey: .preferred)
     }
     
     init(from decoder: Decoder) throws {
@@ -54,8 +54,9 @@ extension Lane: Codable {
         indications = try container.decode(LaneIndication.self, forKey: .indications)
         isValid = try container.decode(Bool.self, forKey: .valid)
         isActive = try container.decodeIfPresent(Bool.self, forKey: .active)
-        if let validIndicationDescription = try container.decodeIfPresent(String.self, forKey: .preferred) {
-            validIndication = LaneIndication(descriptions: [validIndicationDescription])
-        }
+//        if let validIndicationDescription = try container.decodeIfPresent(String.self, forKey: .preferred) {
+//            validIndication = LaneIndication(descriptions: [validIndicationDescription])
+//        }
+        validIndication = try container.decodeIfPresent(ManeuverDirection.self, forKey: .preferred)
     }
 }

--- a/Sources/MapboxDirections/LaneIndication.swift
+++ b/Sources/MapboxDirections/LaneIndication.swift
@@ -69,6 +69,10 @@ public struct LaneIndication: OptionSet, CustomStringConvertible {
         self.init(rawValue: laneIndication.rawValue)
     }
     
+    public init?(from direction: ManeuverDirection) {
+        self.init(descriptions: [direction.rawValue])
+    }
+    
     public var descriptions: [String] {
         if isEmpty {
             return []

--- a/Sources/MapboxDirections/LaneIndication.swift
+++ b/Sources/MapboxDirections/LaneIndication.swift
@@ -69,7 +69,8 @@ public struct LaneIndication: OptionSet, CustomStringConvertible {
         self.init(rawValue: laneIndication.rawValue)
     }
     
-    public init?(from direction: ManeuverDirection) {
+    init?(from direction: ManeuverDirection) {
+        // Assuming that every possible raw value of ManeuverDirection matches valid raw value of LaneIndication
         self.init(descriptions: [direction.rawValue])
     }
     

--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -263,11 +263,6 @@ public enum ManeuverDirection: String, Codable {
      Use the difference between the step’s initial and final headings to distinguish between a U-turn to the left (typical in countries that drive on the right) and a U-turn on the right (typical in countries that drive on the left). If the difference in headings is greater than 180 degrees, the maneuver requires a U-turn to the left. If the difference in headings is less than 180 degrees, the maneuver requires a U-turn to the right.
      */
     case uTurn = "uturn"
-    
-    /**
-     The maneuver has no direction.
-     */
-    case none
 }
 
 /**

--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -263,6 +263,11 @@ public enum ManeuverDirection: String, Codable {
      Use the difference between the step’s initial and final headings to distinguish between a U-turn to the left (typical in countries that drive on the right) and a U-turn on the right (typical in countries that drive on the left). If the difference in headings is greater than 180 degrees, the maneuver requires a U-turn to the left. If the difference in headings is less than 180 degrees, the maneuver requires a U-turn to the right.
      */
     case uTurn = "uturn"
+    
+    /**
+     The maneuver has no direction.
+     */
+    case none
 }
 
 /**

--- a/Sources/MapboxDirections/VisualInstructionComponent.swift
+++ b/Sources/MapboxDirections/VisualInstructionComponent.swift
@@ -217,10 +217,6 @@ extension VisualInstruction.Component: Codable {
         if kind == .lane {
             let indications = try container.decode(LaneIndication.self, forKey: .directions)
             let isUsable = try container.decode(Bool.self, forKey: .isActive)
-//            var preferredDirection: ManeuverDirection? = nil
-//            if let preferredDirectionDescription = try container.decodeIfPresent(ManeuverDirection.self, forKey: .activeDirection) {
-//                preferredDirection = ManeuverDirection(rawValue: preferredDirectionDescription)
-//            }
             let preferredDirection = try container.decodeIfPresent(ManeuverDirection.self, forKey: .activeDirection)
             self = .lane(indications: indications, isUsable: isUsable, preferredDirection: preferredDirection)
             return

--- a/Sources/MapboxDirections/VisualInstructionComponent.swift
+++ b/Sources/MapboxDirections/VisualInstructionComponent.swift
@@ -74,7 +74,7 @@ public extension VisualInstruction {
          - parameter isUsable: Whether the user can use this lane to continue along the current route.
          - parameter preferredDirection: Which of the `indications` is applicable to the current route when there is more than one
          */
-        case lane(indications: LaneIndication, isUsable: Bool, preferredDirection: LaneIndication?)
+        case lane(indications: LaneIndication, isUsable: Bool, preferredDirection: ManeuverDirection?)
     }
 }
 
@@ -217,10 +217,11 @@ extension VisualInstruction.Component: Codable {
         if kind == .lane {
             let indications = try container.decode(LaneIndication.self, forKey: .directions)
             let isUsable = try container.decode(Bool.self, forKey: .isActive)
-            var preferredDirection: LaneIndication? = nil
-            if let preferredDirectionDescription = try container.decodeIfPresent(String.self, forKey: .activeDirection) {
-                preferredDirection = LaneIndication(descriptions: [preferredDirectionDescription])
-            }
+//            var preferredDirection: ManeuverDirection? = nil
+//            if let preferredDirectionDescription = try container.decodeIfPresent(ManeuverDirection.self, forKey: .activeDirection) {
+//                preferredDirection = ManeuverDirection(rawValue: preferredDirectionDescription)
+//            }
+            let preferredDirection = try container.decodeIfPresent(ManeuverDirection.self, forKey: .activeDirection)
             self = .lane(indications: indications, isUsable: isUsable, preferredDirection: preferredDirection)
             return
         }
@@ -284,7 +285,7 @@ extension VisualInstruction.Component: Codable {
             textRepresentation = .init(text: "", abbreviation: nil, abbreviationPriority: nil)
             try container.encode(indications, forKey: .directions)
             try container.encode(isUsable, forKey: .isActive)
-            try container.encodeIfPresent(preferredDirection?.descriptions.first, forKey: .activeDirection)
+            try container.encodeIfPresent(preferredDirection, forKey: .activeDirection)
         case .guidanceView(let image, let alternativeText):
             try container.encode(Kind.guidanceView, forKey: .kind)
             textRepresentation = alternativeText

--- a/Tests/MapboxDirectionsTests/IntersectionTests.swift
+++ b/Tests/MapboxDirectionsTests/IntersectionTests.swift
@@ -96,7 +96,7 @@ class IntersectionTests: XCTestCase {
                          approachLanes: [.straightAhead, [.straightAhead, .right]],
                          usableApproachLanes: IndexSet([0, 1]),
                          preferredApproachLanes: IndexSet([1]),
-                         usableLaneIndication: [.straightAhead],
+                         usableLaneIndication: .straightAhead,
                          outletRoadClasses: nil,
                          tollCollection: nil,
                          tunnelName: nil,


### PR DESCRIPTION
### Description
This PR is to change the type of preferred lane direction from `LaneIndication` to `ManeuverDirection` to remove the hacks introduced in #529 and #532 and avoid converting within the Nav SDK.
- [x] Update property type for preferred lane direction propeties
- [x] Update tests