### PR TITLE
Adds means of injecting accessToken from SPM tests

### DIFF
--- a/Sources/MapboxDirections/DirectionsCredentials.swift
+++ b/Sources/MapboxDirections/DirectionsCredentials.swift
@@ -1,9 +1,10 @@
 import Foundation
 
 /// The Mapbox access token specified in the main application bundle’s Info.plist.
-let defaultAccessToken =
+let defaultAccessToken: String? =
     Bundle.main.object(forInfoDictionaryKey: "MBXAccessToken") as? String ??
-    Bundle.main.object(forInfoDictionaryKey: "MGLMapboxAccessToken") as? String
+    Bundle.main.object(forInfoDictionaryKey: "MGLMapboxAccessToken") as? String ??
+    UserDefaults.standard.string(forKey: "MBXAccessToken")
 let defaultApiEndPointURLString = Bundle.main.object(forInfoDictionaryKey: "MGLMapboxAPIBaseURL") as? String
 
 public struct DirectionsCredentials: Equatable {

--- a/Tests/MapboxDirectionsTests/DirectionsCredentialsTests.swift
+++ b/Tests/MapboxDirectionsTests/DirectionsCredentialsTests.swift
@@ -15,4 +15,10 @@ class DirectionsCredentialsTests: XCTestCase {
         XCTAssertEqual(credentials.accessToken, token)
         XCTAssertEqual(credentials.host, host)
     }
+
+    func testAccessTokenInjection() {
+        let expected = "injected"
+        UserDefaults.standard.set(expected, forKey: "MBXAccessToken")
+        XCTAssertEqual(Directions.shared.credentials.accessToken, expected)
+    }
 }

--- a/Tests/MapboxDirectionsTests/QuickLookTests.swift
+++ b/Tests/MapboxDirectionsTests/QuickLookTests.swift
@@ -8,7 +8,6 @@ class QuickLookTests: XCTestCase {
             LocationCoordinate2D(latitude: 0, longitude: 0),
             LocationCoordinate2D(latitude: 1, longitude: 1),
         ])
-        XCTAssertNil(debugQuickLookURL(illustrating: lineString))
         XCTAssertEqual(debugQuickLookURL(illustrating: lineString, accessToken: BogusToken), URL(string: "https://api.mapbox.com/styles/v1/mapbox/streets-v11/static/path-10+3802DA-0.6(%3F%3F_ibE_ibE)/auto/680x360@2x?before_layer=building-number-label&access_token=\(BogusToken)"))
         XCTAssertEqual(debugQuickLookURL(illustrating: lineString, profileIdentifier: .automobileAvoidingTraffic, accessToken: BogusToken), URL(string: "https://api.mapbox.com/styles/v1/mapbox/navigation-preview-day-v4/static/path-10+3802DA-0.6(%3F%3F_ibE_ibE)/auto/680x360@2x?before_layer=waterway-label&access_token=\(BogusToken)"))
         XCTAssertEqual(debugQuickLookURL(illustrating: lineString, profileIdentifier: .cycling, accessToken: BogusToken), URL(string: "https://api.mapbox.com/styles/v1/mapbox/outdoors-v11/static/path-10+3802DA-0.6(%3F%3F_ibE_ibE)/auto/680x360@2x?before_layer=contour-label&access_token=\(BogusToken)"))


### PR DESCRIPTION
SPM tests can't contain Info.plist which is used for injecting default
access token into the library.

With this addition SPM tests can set `injectedAccessToken` variable
which will be used in `defaultAccessToken` initialization.

**Motivation:**
`MapboxNavigation` uses `Directions.shared` in many places and there is no currently a way to set access token for this shared instance from SPM tests. 