### PR TITLE
RouteOptions.alleyPriority, walkwayPriority, speed are now optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Carthage v0.38 or above is now required for installing this SDK if you use Carthage. ([#548](https://github.com/mapbox/mapbox-directions-swift/pull/548))
 * Xcode 12.0 or above is now required to build MapboxDirections from source. ([#548](https://github.com/mapbox/mapbox-directions-swift/pull/548))
 * You can fully build this SDK on Macs with Apple Silicon. ([#548](https://github.com/mapbox/mapbox-directions-swift/pull/548))
-* `RouteOptions.alleyPriority`, `RouteOptions.walkwayPriority`, and `RouteOptions.speed` are now optional, and thus must be set explicitly if the developer wants to include them in the route options. `DirectionsOptions.default` has been renamed to `DirectionsOptions.medium`. ([#557](https://github.com/mapbox/mapbox-directions-swift/pull/557))
+* `RouteOptions.alleyPriority`, `RouteOptions.walkwayPriority`, and `RouteOptions.speed` are now optional. Set them explicitly if you want to include them in the HTTP request. Renamed `DirectionsOptions.default` to `DirectionsOptions.medium`. ([#557](https://github.com/mapbox/mapbox-directions-swift/pull/557))
 
 ## v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Carthage v0.38 or above is now required for installing this SDK if you use Carthage. ([#548](https://github.com/mapbox/mapbox-directions-swift/pull/548))
 * Xcode 12.0 or above is now required to build MapboxDirections from source. ([#548](https://github.com/mapbox/mapbox-directions-swift/pull/548))
 * You can fully build this SDK on Macs with Apple Silicon. ([#548](https://github.com/mapbox/mapbox-directions-swift/pull/548))
+* `RouteOptions.alleyPriority`, `RouteOptions.walkwayPriority`, and `RouteOptions.speed` are now optional, and thus must be set explicitly if the developer wants to include them in the route options. `DirectionsOptions.default` has been renamed to `DirectionsOptions.medium`. ([#557](https://github.com/mapbox/mapbox-directions-swift/pull/557))
 
 ## v1.2.0
 

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -99,6 +99,7 @@ public struct DirectionsPriority: Hashable, RawRepresentable {
     /**
      The priority level with which a route neither avoids nor prefers a particular type of roadway or pathway.
      */
+    // should we remove this default (or change its naming) if we don't set it as such?
     static let `default` = DirectionsPriority(rawValue: 0.0)
     
     /**

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -99,8 +99,7 @@ public struct DirectionsPriority: Hashable, RawRepresentable {
     /**
      The priority level with which a route neither avoids nor prefers a particular type of roadway or pathway.
      */
-    // should we remove this default (or change its naming) if we don't set it as such?
-    static let `default` = DirectionsPriority(rawValue: 0.0)
+    static let medium = DirectionsPriority(rawValue: 0.0)
     
     /**
      The priority level with which a route prefers a particular type of roadway or pathway.

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -187,16 +187,16 @@ open class RouteOptions: DirectionsOptions {
         if includesExitRoundaboutManeuver {
             params.append(URLQueryItem(name: "roundabout_exits", value: String(includesExitRoundaboutManeuver)))
         }
-        if alleyPriority != nil {
-            params.append(URLQueryItem(name: "alley_bias", value: String(alleyPriority.rawValue)))
+        if let alleyPriority = alleyPriority?.rawValue {
+            params.append(URLQueryItem(name: "alley_bias", value: String(alleyPriority)))
         }
         
-        if walkwayPriority != nil {
-            params.append(URLQueryItem(name: "walkway_bias", value: String(walkwayPriority.rawValue)))
+        if let walkwayPriority = walkwayPriority?.rawValue {
+            params.append(URLQueryItem(name: "walkway_bias", value: String(walkwayPriority)))
         }
         
         if speed != nil {
-            params.append(URLQueryItem(name: "walking_speed", value: String(speed)))
+            params.append(URLQueryItem(name: "walking_speed", value: String(speed!)))
         }
         
         if !roadClassesToAvoid.isEmpty {

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -129,7 +129,7 @@ open class RouteOptions: DirectionsOptions {
      
      The value of this property must be at least `DirectionsPriority.low` and at most `DirectionsPriority.high`. The default value of `DirectionsPriority.default` neither prefers nor avoids alleys, while a negative value between `DirectionsPriority.low` and `DirectionsPriority.default` avoids alleys, and a positive value between `DirectionsPriority.default` and `DirectionsPriority.high` prefers alleys. A value of 0.9 is suitable for pedestrians who are comfortable with walking down alleys.
      */
-    open var alleyPriority: DirectionsPriority = .default
+    open var alleyPriority: DirectionsPriority?
     
     /**
      A number that influences whether the route should prefer or avoid roads or paths that are set aside for pedestrian-only use (walkways or footpaths).
@@ -138,7 +138,7 @@ open class RouteOptions: DirectionsOptions {
      
      The value of this property must be at least `DirectionsPriority.low` and at most `DirectionsPriority.high`. The default value of `DirectionsPriority.default` neither prefers nor avoids walkways, while a negative value between `DirectionsPriority.low` and `DirectionsPriority.default` avoids walkways, and a positive value between `DirectionsPriority.default` and `DirectionsPriority.high` prefers walkways. A value of −0.1 results in less verbose routes in cities where sidewalks and crosswalks are generally mapped as separate footpaths.
      */
-    open var walkwayPriority: DirectionsPriority = .default
+    open var walkwayPriority: DirectionsPriority?
     
     /**
      The expected uniform travel speed measured in meters per second.
@@ -147,7 +147,7 @@ open class RouteOptions: DirectionsOptions {
      
      The value of this property must be at least `CLLocationSpeed.minimumWalking` and at most `CLLocationSpeed.maximumWalking`. The default value is `CLLocationSpeed.normalWalking`.
      */
-    open var speed: LocationSpeed = .normalWalking
+    open var speed: LocationSpeed?
     
     // MARK: Specifying the Response Format
 
@@ -187,12 +187,15 @@ open class RouteOptions: DirectionsOptions {
         if includesExitRoundaboutManeuver {
             params.append(URLQueryItem(name: "roundabout_exits", value: String(includesExitRoundaboutManeuver)))
         }
-
-        if profileIdentifier == .automobile || profileIdentifier == .walking {
+        if alleyPriority != nil {
             params.append(URLQueryItem(name: "alley_bias", value: String(alleyPriority.rawValue)))
         }
-        if profileIdentifier == .walking {
+        
+        if walkwayPriority != nil {
             params.append(URLQueryItem(name: "walkway_bias", value: String(walkwayPriority.rawValue)))
+        }
+        
+        if speed != nil {
             params.append(URLQueryItem(name: "walking_speed", value: String(speed)))
         }
         

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -195,8 +195,8 @@ open class RouteOptions: DirectionsOptions {
             params.append(URLQueryItem(name: "walkway_bias", value: String(walkwayPriority)))
         }
         
-        if speed != nil {
-            params.append(URLQueryItem(name: "walking_speed", value: String(speed!)))
+        if let speed = speed {
+            params.append(URLQueryItem(name: "walking_speed", value: String(speed)))
         }
         
         if !roadClassesToAvoid.isEmpty {

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -123,29 +123,29 @@ open class RouteOptions: DirectionsOptions {
     open var roadClassesToAvoid: RoadClasses = []
     
     /**
-     A number that influences whether the route should prefer or avoid alleys or narrow service roads between buildings.
+     An optional that represents the number that influences whether the route should prefer or avoid alleys or narrow service roads between buildings.
      
-     This property has no effect unless the profile identifier is set to `DirectionsProfileIdentifier.automobile` or `DirectionsProfileIdentifier.walking`.
+     This property has no effect unless it is explicitly set as it defaults to nil, and works best when the profile identifier is set to `DirectionsProfileIdentifier.automobile` or `DirectionsProfileIdentifier.walking`.
      
-     The value of this property must be at least `DirectionsPriority.low` and at most `DirectionsPriority.high`. The default value of `DirectionsPriority.default` neither prefers nor avoids alleys, while a negative value between `DirectionsPriority.low` and `DirectionsPriority.default` avoids alleys, and a positive value between `DirectionsPriority.default` and `DirectionsPriority.high` prefers alleys. A value of 0.9 is suitable for pedestrians who are comfortable with walking down alleys.
+     The value of this property must be at least `DirectionsPriority.low` and at most `DirectionsPriority.high`. `DirectionsPriority.medium` neither prefers nor avoids alleys, while a negative value between `DirectionsPriority.low` and `DirectionsPriority.medium` avoids alleys, and a positive value between `DirectionsPriority.medium` and `DirectionsPriority.high` prefers alleys. A value of 0.9 is suitable for pedestrians who are comfortable with walking down alleys.
      */
     open var alleyPriority: DirectionsPriority?
     
     /**
-     A number that influences whether the route should prefer or avoid roads or paths that are set aside for pedestrian-only use (walkways or footpaths).
+     An optional that represents the number that influences whether the route should prefer or avoid roads or paths that are set aside for pedestrian-only use (walkways or footpaths).
      
-     This property has no effect unless the profile identifier is set to `DirectionsProfileIdentifier.walking`. You can adjust this property to avoid [sidewalks and crosswalks that are mapped as separate footpaths](https://wiki.openstreetmap.org/wiki/Sidewalks#Sidewalk_as_separate_way), which may be more granular than needed for some forms of pedestrian navigation.
+     This property has no effect unless it is explicitly set as it defaults to nil, and works best when the profile identifier is set to `DirectionsProfileIdentifier.walking`. You can adjust this property to avoid [sidewalks and crosswalks that are mapped as separate footpaths](https://wiki.openstreetmap.org/wiki/Sidewalks#Sidewalk_as_separate_way), which may be more granular than needed for some forms of pedestrian navigation.
      
-     The value of this property must be at least `DirectionsPriority.low` and at most `DirectionsPriority.high`. The default value of `DirectionsPriority.default` neither prefers nor avoids walkways, while a negative value between `DirectionsPriority.low` and `DirectionsPriority.default` avoids walkways, and a positive value between `DirectionsPriority.default` and `DirectionsPriority.high` prefers walkways. A value of −0.1 results in less verbose routes in cities where sidewalks and crosswalks are generally mapped as separate footpaths.
+     The value of this property must be at least `DirectionsPriority.low` and at most `DirectionsPriority.high`. `DirectionsPriority.medium` neither prefers nor avoids walkways, while a negative value between `DirectionsPriority.low` and `DirectionsPriority.medium` avoids walkways, and a positive value between `DirectionsPriority.medium` and `DirectionsPriority.high` prefers walkways. A value of −0.1 results in less verbose routes in cities where sidewalks and crosswalks are generally mapped as separate footpaths.
      */
     open var walkwayPriority: DirectionsPriority?
     
     /**
-     The expected uniform travel speed measured in meters per second.
+     An optional that represents the expected uniform travel speed measured in meters per second.
      
-     This property has no effect unless the profile identifier is set to `DirectionsProfileIdentifier.walking`. You can adjust this property to account for running or for faster or slower gaits. When the profile identifier is set to another profile identifier, such as `DirectionsProfileIdentifier.driving`, this property is ignored in favor of the expected travel speed on each road along the route. This property may be supported by other routing profiles in the future.
+     This property has no effect unless it is explicitly set as it defaults to nil, and works best when the profile identifier is set to `DirectionsProfileIdentifier.walking`. You can adjust this property to account for running or for faster or slower gaits. When the profile identifier is set to another profile identifier, such as `DirectionsProfileIdentifier.driving`, this property is ignored in favor of the expected travel speed on each road along the route. This property may be supported by other routing profiles in the future.
      
-     The value of this property must be at least `CLLocationSpeed.minimumWalking` and at most `CLLocationSpeed.maximumWalking`. The default value is `CLLocationSpeed.normalWalking`.
+     The value of this property must be at least `CLLocationSpeed.minimumWalking` and at most `CLLocationSpeed.maximumWalking`. `CLLocationSpeed.normalWalking` corresponds to a typical preferred walking speed.
      */
     open var speed: LocationSpeed?
     
@@ -222,7 +222,7 @@ open class RouteOptions: DirectionsOptions {
 
 extension LocationSpeed {
     /**
-     By default, pedestrians are assumed to walk at an average rate of 1.42 meters per second (5.11 kilometers per hour or 3.18 miles per hour), corresponding to a typical preferred walking speed.
+     Pedestrians are assumed to walk at an average rate of 1.42 meters per second (5.11 kilometers per hour or 3.18 miles per hour), corresponding to a typical preferred walking speed.
      */
     static let normalWalking: LocationSpeed = 1.42
     

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -123,27 +123,30 @@ open class RouteOptions: DirectionsOptions {
     open var roadClassesToAvoid: RoadClasses = []
     
     /**
-     An optional that represents the number that influences whether the route should prefer or avoid alleys or narrow service roads between buildings.
+     The number that influences whether the route should prefer or avoid alleys or narrow service roads between buildings.
+     If this property isn't explicitly set, the Directions API will choose the most reasonable value.
      
-     This property has no effect unless it is explicitly set as it defaults to nil, and works best when the profile identifier is set to `DirectionsProfileIdentifier.automobile` or `DirectionsProfileIdentifier.walking`.
+     This property has no effect unless the profile identifier is set to `DirectionsProfileIdentifier.automobile` or `DirectionsProfileIdentifier.walking`.
      
      The value of this property must be at least `DirectionsPriority.low` and at most `DirectionsPriority.high`. `DirectionsPriority.medium` neither prefers nor avoids alleys, while a negative value between `DirectionsPriority.low` and `DirectionsPriority.medium` avoids alleys, and a positive value between `DirectionsPriority.medium` and `DirectionsPriority.high` prefers alleys. A value of 0.9 is suitable for pedestrians who are comfortable with walking down alleys.
      */
     open var alleyPriority: DirectionsPriority?
     
     /**
-     An optional that represents the number that influences whether the route should prefer or avoid roads or paths that are set aside for pedestrian-only use (walkways or footpaths).
+     The number that influences whether the route should prefer or avoid roads or paths that are set aside for pedestrian-only use (walkways or footpaths).
+     If this property isn't explicitly set, the Directions API will choose the most reasonable value.
      
-     This property has no effect unless it is explicitly set as it defaults to nil, and works best when the profile identifier is set to `DirectionsProfileIdentifier.walking`. You can adjust this property to avoid [sidewalks and crosswalks that are mapped as separate footpaths](https://wiki.openstreetmap.org/wiki/Sidewalks#Sidewalk_as_separate_way), which may be more granular than needed for some forms of pedestrian navigation.
+     This property has no effect unless the profile identifier is set to `DirectionsProfileIdentifier.walking`. You can adjust this property to avoid [sidewalks and crosswalks that are mapped as separate footpaths](https://wiki.openstreetmap.org/wiki/Sidewalks#Sidewalk_as_separate_way), which may be more granular than needed for some forms of pedestrian navigation.
      
      The value of this property must be at least `DirectionsPriority.low` and at most `DirectionsPriority.high`. `DirectionsPriority.medium` neither prefers nor avoids walkways, while a negative value between `DirectionsPriority.low` and `DirectionsPriority.medium` avoids walkways, and a positive value between `DirectionsPriority.medium` and `DirectionsPriority.high` prefers walkways. A value of −0.1 results in less verbose routes in cities where sidewalks and crosswalks are generally mapped as separate footpaths.
      */
     open var walkwayPriority: DirectionsPriority?
     
     /**
-     An optional that represents the expected uniform travel speed measured in meters per second.
+     The expected uniform travel speed measured in meters per second.
+     If this property isn't explicitly set, the Directions API will choose the most reasonable value.
      
-     This property has no effect unless it is explicitly set as it defaults to nil, and works best when the profile identifier is set to `DirectionsProfileIdentifier.walking`. You can adjust this property to account for running or for faster or slower gaits. When the profile identifier is set to another profile identifier, such as `DirectionsProfileIdentifier.driving`, this property is ignored in favor of the expected travel speed on each road along the route. This property may be supported by other routing profiles in the future.
+     This property has no effect unless the profile identifier is set to `DirectionsProfileIdentifier.walking`. You can adjust this property to account for running or for faster or slower gaits. When the profile identifier is set to another profile identifier, such as `DirectionsProfileIdentifier.driving`, this property is ignored in favor of the expected travel speed on each road along the route. This property may be supported by other routing profiles in the future.
      
      The value of this property must be at least `CLLocationSpeed.minimumWalking` and at most `CLLocationSpeed.maximumWalking`. `CLLocationSpeed.normalWalking` corresponds to a typical preferred walking speed.
      */

--- a/Tests/MapboxDirectionsTests/DirectionsTests.swift
+++ b/Tests/MapboxDirectionsTests/DirectionsTests.swift
@@ -73,7 +73,7 @@ class DirectionsTests: XCTestCase {
     func testPOSTRequest() {
         let coordinates = Array(repeating: LocationCoordinate2D(latitude: 0, longitude: 0), count: maximumCoordinateCount + 1)
         let options = RouteOptions(coordinates: coordinates)
-        options.alleyPriority = .default
+        options.alleyPriority = .medium
         
         let directions = Directions(credentials: BogusCredentials)
         let request = directions.urlRequest(forCalculating: options)

--- a/Tests/MapboxDirectionsTests/DirectionsTests.swift
+++ b/Tests/MapboxDirectionsTests/DirectionsTests.swift
@@ -73,6 +73,7 @@ class DirectionsTests: XCTestCase {
     func testPOSTRequest() {
         let coordinates = Array(repeating: LocationCoordinate2D(latitude: 0, longitude: 0), count: maximumCoordinateCount + 1)
         let options = RouteOptions(coordinates: coordinates)
+        options.alleyPriority = .default
         
         let directions = Directions(credentials: BogusCredentials)
         let request = directions.urlRequest(forCalculating: options)

--- a/Tests/MapboxDirectionsTests/DirectionsTests.swift
+++ b/Tests/MapboxDirectionsTests/DirectionsTests.swift
@@ -62,7 +62,7 @@ class DirectionsTests: XCTestCase {
         XCTAssertLessThanOrEqual(url.absoluteString.count, MaximumURLLength, "maximumCoordinateCount is too high")
         
         let components = URLComponents(string: url.absoluteString)
-        XCTAssertEqual(components?.queryItems?.count, 8)
+        XCTAssertEqual(components?.queryItems?.count, 7)
         XCTAssertTrue(components?.path.contains(coordinates.compactMap { $0.requestDescription }.joined(separator: ";")) ?? false)
         
         let request = directions.urlRequest(forCalculating: options)

--- a/Tests/MapboxDirectionsTests/WalkingOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/WalkingOptionsTests.swift
@@ -16,10 +16,6 @@ class WalkingOptionsTests: XCTestCase {
         XCTAssertNil(queryItems.first { $0.name == "walkway_bias" }?.value)
         XCTAssertNil(queryItems.first { $0.name == "walking_speed" }?.value)
         
-//        XCTAssertEqual(queryItems.first { $0.name == "alley_bias" }?.value, nil)
-//        XCTAssertEqual(queryItems.first { $0.name == "walkway_bias" }?.value, nil)
-//        XCTAssertEqual(queryItems.first { $0.name == "walking_speed" }?.value, "1.42")
-        
         options.alleyPriority = DirectionsPriority(rawValue: 0.4)
         options.walkwayPriority = DirectionsPriority(rawValue: 0.5)
         options.speed = 5.2

--- a/Tests/MapboxDirectionsTests/WalkingOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/WalkingOptionsTests.swift
@@ -12,10 +12,13 @@ class WalkingOptionsTests: XCTestCase {
 
         let options = RouteOptions(waypoints: waypoints, profileIdentifier: DirectionsProfileIdentifier.walking)
         var queryItems = options.urlQueryItems
-
-         XCTAssertEqual(queryItems.first { $0.name == "alley_bias" }?.value, "0.0")
-        XCTAssertEqual(queryItems.first { $0.name == "walkway_bias" }?.value, "0.0")
-        XCTAssertEqual(queryItems.first { $0.name == "walking_speed" }?.value, "1.42")
+        XCTAssertNil(queryItems.first { $0.name == "alley_bias" }?.value)
+        XCTAssertNil(queryItems.first { $0.name == "walkway_bias" }?.value)
+        XCTAssertNil(queryItems.first { $0.name == "walking_speed" }?.value)
+        
+//        XCTAssertEqual(queryItems.first { $0.name == "alley_bias" }?.value, nil)
+//        XCTAssertEqual(queryItems.first { $0.name == "walkway_bias" }?.value, nil)
+//        XCTAssertEqual(queryItems.first { $0.name == "walking_speed" }?.value, "1.42")
         
         options.alleyPriority = DirectionsPriority(rawValue: 0.4)
         options.walkwayPriority = DirectionsPriority(rawValue: 0.5)


### PR DESCRIPTION
This PR addresses #553 by making `RouteOptions.alleyPriority`, `walkwayPriority`, and `speed` optional properties and conditionally adding their corresponding URL query items to `RouteOptions.urlQueryItems`.