### PR TITLE
Fix bug where leg source and destination are mismatched when route contains trackpoint or silent waypoint

### DIFF
--- a/Sources/MapboxDirections/DirectionsResult.swift
+++ b/Sources/MapboxDirections/DirectionsResult.swift
@@ -41,8 +41,8 @@ open class DirectionsResult: Codable {
         
         //populate legs with origin and destination
         if let options = options as? DirectionsOptions {
-            let waypoints = options.waypoints
-            legs.populate(waypoints: waypoints)
+            let legSeparators = options.legSeparators
+            legs.populate(waypoints: legSeparators)
         } else {
             throw DirectionsCodingError.missingOptions
         }


### PR DESCRIPTION
This PR addresses #556 by passing `DirectionsOptions.legSeparators` into `Array.populate(waypoints:)`, rather than passing in `DirectionsOptions.waypoints`. It fixes a regression of #358 was introduced by #406.

/cc @ZiZasaurus 