### PR TITLE
RouteIdentifier removing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Xcode 12.0 or above is now required to build MapboxDirections from source. ([#548](https://github.com/mapbox/mapbox-directions-swift/pull/548))
 * You can fully build this SDK on Macs with Apple Silicon. ([#548](https://github.com/mapbox/mapbox-directions-swift/pull/548))
 * `RouteOptions.alleyPriority`, `RouteOptions.walkwayPriority`, and `RouteOptions.speed` are now optional. Set them explicitly if you want to include them in the HTTP request. Renamed `DirectionsOptions.default` to `DirectionsOptions.medium`. ([#557](https://github.com/mapbox/mapbox-directions-swift/pull/557))
-* Removed obsolete `DirectionsResult.routeIdentifier` property. It is recommended to use corresponding `RouteResponse.identifier` value in conjunction with `Route` index in `RouteResponse.routes` array instead ([#562](https://github.com/mapbox/mapbox-directions-swift/pull/562)).
+* Removed the `DirectionsResult.routeIdentifier` property. Use the `RouteResponse.identifier` property in conjunction with an index into the `RouteResponse.routes` array instead. ([#562](https://github.com/mapbox/mapbox-directions-swift/pull/562))
 
 ## v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Xcode 12.0 or above is now required to build MapboxDirections from source. ([#548](https://github.com/mapbox/mapbox-directions-swift/pull/548))
 * You can fully build this SDK on Macs with Apple Silicon. ([#548](https://github.com/mapbox/mapbox-directions-swift/pull/548))
 * `RouteOptions.alleyPriority`, `RouteOptions.walkwayPriority`, and `RouteOptions.speed` are now optional. Set them explicitly if you want to include them in the HTTP request. Renamed `DirectionsOptions.default` to `DirectionsOptions.medium`. ([#557](https://github.com/mapbox/mapbox-directions-swift/pull/557))
+* Removed obsolete `DirectionsResult.routeIdentifier` property. It is recommended to use corresponding `RouteResponse.identifier` value in conjunction with `Route` index in `RouteResponse.routes` array instead ([#562](https://github.com/mapbox/mapbox-directions-swift/pull/562)).
 
 ## v1.2.0
 

--- a/Directions Example/ContentView.swift
+++ b/Directions Example/ContentView.swift
@@ -73,7 +73,7 @@ struct ContentView: View {
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 10, content: {
-                ForEach(vm.routes, id: \.routeIdentifier) { route in
+                ForEach(vm.routes, id: \.distance) { route in
                     VStack(alignment: .leading, spacing: 3) {
                         headerView(for: route)
                         ForEach(0..<route.legs.count, id: \.self) { legIdx in

--- a/Sources/MapboxDirections/Directions.swift
+++ b/Sources/MapboxDirections/Directions.swift
@@ -402,7 +402,7 @@ open class Directions: NSObject {
      
      - precondition: Set `RouteOptions.refreshingEnabled` to `true` when calculating the original route.
      
-     - parameter responseIdentifier: The `RouteResponse.identifier` value of the `RouteResponse` that contains the route to refresh. You can alternatively use the value of `Route.routeIdentifier`.
+     - parameter responseIdentifier: The `RouteResponse.identifier` value of the `RouteResponse` that contains the route to refresh.
      - parameter routeIndex: The index of the route to refresh in the original `RouteResponse.routes` array.
      - parameter startLegIndex: The index of the leg in the route at which to begin refreshing. The response will omit any leg before this index and refresh any leg from this index to the end of the route. If this argument is omitted, the entire route is refreshed.
      - parameter completionHandler: The closure (block) to call with the resulting skeleton route data. This closure is executed on the application’s main thread.

--- a/Sources/MapboxDirections/DirectionsResult.swift
+++ b/Sources/MapboxDirections/DirectionsResult.swift
@@ -15,7 +15,6 @@ open class DirectionsResult: Codable {
         case expectedTravelTime = "duration"
         case typicalTravelTime = "duration_typical"
         case directionsOptions
-        case routeIdentifier
         case speechLocale = "voiceLocale"
     }
     
@@ -57,8 +56,6 @@ open class DirectionsResult: Codable {
         } else {
             shape = nil
         }
-     
-        routeIdentifier = try container.decodeIfPresent(String.self, forKey: .routeIdentifier)
         
         if let identifier = try container.decodeIfPresent(String.self, forKey: .speechLocale) {
             speechLocale = Locale(identifier: identifier)
@@ -82,7 +79,6 @@ open class DirectionsResult: Codable {
         try container.encode(distance, forKey: .distance)
         try container.encode(expectedTravelTime, forKey: .expectedTravelTime)
         try container.encodeIfPresent(typicalTravelTime, forKey: .typicalTravelTime)
-        try container.encodeIfPresent(routeIdentifier, forKey: .routeIdentifier)
 
         if responseContainsSpeechLocale {
             try container.encode(speechLocale?.identifier, forKey: .speechLocale)
@@ -161,13 +157,6 @@ open class DirectionsResult: Codable {
     open var speechLocale: Locale?
     
     // MARK: Auditing the Server Response
-    
-    /**
-     A unique identifier for a directions request.
-     
-     Each route produced by a single call to `Directions.calculate(_:completionHandler:)` has the same route identifier.
-     */
-    open var routeIdentifier: String?
     
     /**
      The time immediately before a `Directions` object fetched this result.

--- a/Sources/MapboxDirections/MapMatching/Match.swift
+++ b/Sources/MapboxDirections/MapMatching/Match.swift
@@ -107,8 +107,7 @@ open class Match: DirectionsResult {
 
 extension Match: Equatable {
     public static func ==(lhs: Match, rhs: Match) -> Bool {
-        return lhs.routeIdentifier == rhs.routeIdentifier &&
-            lhs.distance == rhs.distance &&
+        return lhs.distance == rhs.distance &&
             lhs.expectedTravelTime == rhs.expectedTravelTime &&
             lhs.speechLocale == rhs.speechLocale &&
             lhs.responseContainsSpeechLocale == rhs.responseContainsSpeechLocale &&

--- a/Sources/MapboxDirections/Route.swift
+++ b/Sources/MapboxDirections/Route.swift
@@ -34,8 +34,7 @@ open class Route: DirectionsResult {
 
 extension Route: Equatable {
     public static func ==(lhs: Route, rhs: Route) -> Bool {
-        return lhs.routeIdentifier == rhs.routeIdentifier &&
-            lhs.distance == rhs.distance &&
+        return lhs.distance == rhs.distance &&
             lhs.expectedTravelTime == rhs.expectedTravelTime &&
             lhs.typicalTravelTime == rhs.typicalTravelTime &&
             lhs.speechLocale == rhs.speechLocale &&

--- a/Sources/MapboxDirections/RouteResponse.swift
+++ b/Sources/MapboxDirections/RouteResponse.swift
@@ -131,7 +131,6 @@ extension RouteResponse: Codable {
         if let routes = try container.decodeIfPresent([Route].self, forKey: .routes) {
             // Postprocess each route.
             for route in routes {
-                route.routeIdentifier = identifier
                 // Imbue each route’s legs with the waypoints refined above.
                 if let waypoints = waypoints {
                     route.legSeparators = waypoints.filter { $0.separatesLegs }

--- a/Tests/MapboxDirectionsTests/AnnotationTests.swift
+++ b/Tests/MapboxDirectionsTests/AnnotationTests.swift
@@ -66,7 +66,6 @@ class AnnotationTests: XCTestCase {
         if let route = route {
             XCTAssertNotNil(route.shape)
             XCTAssertEqual(route.shape?.coordinates.count, 154)
-            XCTAssertEqual(route.routeIdentifier, "ck4f22iso03fm78o2f96mt5e9")
             XCTAssertEqual(route.legs.count, 1)
         }
         

--- a/Tests/MapboxDirectionsTests/MatchTests.swift
+++ b/Tests/MapboxDirectionsTests/MatchTests.swift
@@ -67,7 +67,6 @@ class MatchTests: XCTestCase {
         XCTAssertNotNil(match)
         XCTAssertNotNil(match.shape)
         XCTAssertEqual(match.shape!.coordinates.count, 18)
-        XCTAssertEqual(match.routeIdentifier, nil)
         
         let tracePoints = response.tracepoints
         XCTAssertNotNil(tracePoints)

--- a/Tests/MapboxDirectionsTests/RoutableMatchTests.swift
+++ b/Tests/MapboxDirectionsTests/RoutableMatchTests.swift
@@ -61,7 +61,6 @@ class RoutableMatchTest: XCTestCase {
         XCTAssertNotNil(route)
         XCTAssertNotNil(route.shape)
         XCTAssertEqual(route.shape!.coordinates.count, 19)
-        XCTAssertEqual(route.routeIdentifier, nil)
         
         let waypoints = routeResponse.waypoints!
         XCTAssertNotNil(waypoints)

--- a/Tests/MapboxDirectionsTests/V5Tests.swift
+++ b/Tests/MapboxDirectionsTests/V5Tests.swift
@@ -84,8 +84,6 @@ class V5Tests: XCTestCase {
         
         XCTAssertNotNil(route.shape)
         XCTAssertEqual(route.shape!.coordinates.count, 30_097)
-        XCTAssertEqual(route.routeIdentifier?.count, 25)
-        XCTAssertTrue(route.routeIdentifier?.starts(with: "cjsb5x") ?? false)
         XCTAssertEqual(route.speechLocale?.identifier, "en-US")
         
         // confirming actual decoded values is important because the Directions API

--- a/Tests/MapboxDirectionsTests/VisualInstructionTests.swift
+++ b/Tests/MapboxDirectionsTests/VisualInstructionTests.swift
@@ -146,7 +146,6 @@ class VisualInstructionsTests: XCTestCase {
         }
         
         XCTAssertNotNil(route)
-        XCTAssertEqual(route.routeIdentifier, "cjgy4xps418g17mo7l2pdm734")
         
         let leg = route.legs.first!
         let step = leg.steps[1]
@@ -241,7 +240,6 @@ class VisualInstructionsTests: XCTestCase {
         }
         
         XCTAssertNotNil(route)
-        XCTAssertEqual(route.routeIdentifier, "cjikck25m00v279ms1knttdgc")
         
         let step = route.legs.first!.steps.first!
         let visualInstructions = step.instructionsDisplayedAlongStep
@@ -320,7 +318,6 @@ class VisualInstructionsTests: XCTestCase {
           }
         
         XCTAssertNotNil(route)
-        XCTAssertEqual(route.routeIdentifier, "cjilrvx2200447omltwdayvm4")
         
         let step = route.legs.first!.steps.first!
         let visualInstructions = step.instructionsDisplayedAlongStep


### PR DESCRIPTION
This PR removes `DirectionsResult.routeIdentifier` vestigial property.
We encourage using `RouteResponse.identifier` + route array index instead to identify the route.