### PR TITLE
Fixed RouteStep.exitIndex parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * You can fully build this SDK on Macs with Apple Silicon. ([#548](https://github.com/mapbox/mapbox-directions-swift/pull/548))
 * `RouteOptions.alleyPriority`, `RouteOptions.walkwayPriority`, and `RouteOptions.speed` are now optional. Set them explicitly if you want to include them in the HTTP request. Renamed `DirectionsOptions.default` to `DirectionsOptions.medium`. ([#557](https://github.com/mapbox/mapbox-directions-swift/pull/557))
 * Removed the `DirectionsResult.routeIdentifier` property. Use the `RouteResponse.identifier` property in conjunction with an index into the `RouteResponse.routes` array instead. ([#562](https://github.com/mapbox/mapbox-directions-swift/pull/562))
+* Fixed an issue where RouteStep.exitIndex was always unset. ([#567](https://github.com/mapbox/mapbox-directions-swift/pull/567))
 
 ## v1.2.0
 

--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -403,7 +403,6 @@ open class RouteStep: Codable {
         case shape = "geometry"
         case distance
         case drivingSide = "driving_side"
-        case exitIndex = "exit"
         case expectedTravelTime = "duration"
         case typicalTravelTime = "duration_typical"
         case instructions
@@ -422,6 +421,7 @@ open class RouteStep: Codable {
         case instruction
         case location
         case type
+        case exitIndex = "exit"
         case direction = "modifier"
         case initialHeading = "bearing_before"
         case finalHeading = "bearing_after"
@@ -490,7 +490,6 @@ open class RouteStep: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(instructionsSpokenAlongStep, forKey: .instructionsSpokenAlongStep)
         try container.encodeIfPresent(instructionsDisplayedAlongStep, forKey: .instructionsDisplayedAlongStep)
-        try container.encodeIfPresent(exitIndex, forKey: .exitIndex)
         try container.encode(distance.rounded(to: 1e1), forKey: .distance)
         try container.encode(expectedTravelTime.rounded(to: 1e1), forKey: .expectedTravelTime)
         try container.encodeIfPresent(typicalTravelTime?.rounded(to: 1e1), forKey: .typicalTravelTime)
@@ -530,6 +529,8 @@ open class RouteStep: Codable {
         var maneuver = container.nestedContainer(keyedBy: ManeuverCodingKeys.self, forKey: .maneuver)
         try maneuver.encode(instructions, forKey: .instruction)
         try maneuver.encode(maneuverType, forKey: .type)
+        try maneuver.encodeIfPresent(exitIndex, forKey: .exitIndex)
+
         try maneuver.encodeIfPresent(maneuverDirection, forKey: .direction)
         try maneuver.encode(LocationCoordinate2DCodable(maneuverLocation), forKey: .location)
         try maneuver.encodeIfPresent(initialHeading, forKey: .initialHeading)
@@ -586,7 +587,8 @@ open class RouteStep: Codable {
         maneuverLocation = try maneuver.decode(LocationCoordinate2DCodable.self, forKey: .location).decodedCoordinates
         maneuverType = (try? maneuver.decode(ManeuverType.self, forKey: .type)) ?? .default
         maneuverDirection = try maneuver.decodeIfPresent(ManeuverDirection.self, forKey: .direction)
-        
+        exitIndex = try maneuver.decodeIfPresent(Int.self, forKey: .exitIndex)
+
         initialHeading = try maneuver.decodeIfPresent(Turf.LocationDirection.self, forKey: .initialHeading)
         finalHeading = try maneuver.decodeIfPresent(Turf.LocationDirection.self, forKey: .finalHeading)
         
@@ -614,7 +616,6 @@ open class RouteStep: Codable {
             instructionsDisplayedAlongStep = nil
         }
         
-        exitIndex = try container.decodeIfPresent(Int.self, forKey: .exitIndex)
         distance = try container.decode(Turf.LocationDirection.self, forKey: .distance)
         expectedTravelTime = try container.decode(TimeInterval.self, forKey: .expectedTravelTime)
         typicalTravelTime = try container.decodeIfPresent(TimeInterval.self, forKey: .typicalTravelTime)

--- a/Tests/MapboxDirectionsTests/RouteStepTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteStepTests.swift
@@ -336,14 +336,19 @@ class RouteStepTests: XCTestCase {
             var newRoute: Route?
             XCTAssertNoThrow(newRoute = try decoder.decode(Route.self, from: jsonData))
             XCTAssertNotNil(newRoute)
+            guard let leg = newRoute?.legs.first else {
+                XCTFail("No legs found"); return
+            }
             
-            XCTAssert(newRoute!.legs.first!.incidents!.first!.kind == Incident.Kind.miscellaneous)
-            XCTAssert(newRoute!.legs.first!.incidents!.first!.impact == Incident.Impact.minor)
-            XCTAssert(newRoute!.legs.first!.incidents![0].lanesBlocked!.contains(.right))
-            XCTAssertNil(newRoute!.legs.first!.incidents![1].lanesBlocked)
-            XCTAssert(newRoute!.legs.first!.incidents![2].lanesBlocked!.isEmpty)
-            XCTAssert(newRoute!.legs.first!.incidents![2].shapeIndexRange == 810..<900)
-            XCTAssert(newRoute!.legs.first!.incidents!.first! == route.legs.first!.incidents!.first!)
+            XCTAssert(leg.incidents!.first!.kind == Incident.Kind.miscellaneous)
+            XCTAssert(leg.incidents!.first!.impact == Incident.Impact.minor)
+            XCTAssert(leg.incidents![0].lanesBlocked!.contains(.right))
+            XCTAssertNil(leg.incidents![1].lanesBlocked)
+            XCTAssert(leg.incidents![2].lanesBlocked!.isEmpty)
+            XCTAssert(leg.incidents![2].shapeIndexRange == 810..<900)
+            XCTAssert(leg.incidents!.first! == leg.incidents!.first!)
+
+            XCTAssert(leg.steps.contains(where: { $0.exitIndex != nil }))
         }
     }
 }


### PR DESCRIPTION
It was expected that exitIndex was at the top level of RouteStep json
dictionary. But it is actually at "maneuver" sub dictionary.

Fixes #508 and mapbox/mapbox-navigation-ios#2742