### PR TITLE
Add fall back to Directions API request when no input file is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@
 * Added a `RouteLeg.viaWaypoints` property that lists the non-leg-separating waypoints (also known as “silent waypoints”) along a `RouteLeg`. Previously, you had to filter `DirectionsOptions.waypoints` to include only the items whose `Waypoints.separatesLegs` property was set to `true`, then zip them with `RouteResponse.routes`. This approach still works in some cases but is not guaranteed to be reliable for all Mapbox Directions API responses in the future. ([#656](https://github.com/mapbox/mapbox-directions-swift/pull/656))
 
 ## v2.2.0
-
 * Added the `RouteResponse.roadClassViolations` property, which indicates any requested `RouteOptions.roadClassesToAvoid` values that could not be satisfied when calculating the routes. You can use convenience `RouteResponse.exclusionViolations(routeIndex:legIndex:stepIndex:intersectionIndex:)` method to search for a specific item. ([#627](https://github.com/mapbox/mapbox-directions-swift/pull/627))
 * Fixed an issue where `PolyLineString` encoded an invalid GeoJSON LineString. ([#638](https://github.com/mapbox/mapbox-directions-swift/pull/638))
 * Added `RouteRefreshSource` protocol to allow refreshing `Route` objects with `RefreshedRoute` or another `Route` instance. ([#634](https://github.com/mapbox/mapbox-directions-swift/pull/634))
+* The `mapbox-directions-swift` command line tool now requests routes from the Mapbox Directions API if no input file is specified. ([#576](https://github.com/mapbox/mapbox-directions-swift/pull/576))
 
 ## v2.1.0
 

--- a/Sources/MapboxDirectionsCLI/CodingOperation.swift
+++ b/Sources/MapboxDirectionsCLI/CodingOperation.swift
@@ -3,9 +3,10 @@ import MapboxDirections
 import Turf
 import CoreLocation
 
-private let BogusCredentials = Credentials(accessToken: "pk.feedCafeDadeDeadBeef-BadeBede.FadeCafeDadeDeed-BadeBede")
-let accessToken = ProcessInfo.processInfo.environment["access_token"]
-let credentials = DirectionsCredentials(accessToken: accessToken)
+let accessToken: String? =
+    ProcessInfo.processInfo.environment["access_token"] ??
+    UserDefaults.standard.string(forKey: "MBXAccessToken")
+let credentials = DirectionsCredentials(accessToken: accessToken!)
 private let directions = Directions(credentials: credentials)
 
 protocol DirectionsResultsProvider {
@@ -146,8 +147,6 @@ class CodingOperation<ResponseType : Codable & DirectionsResultsProvider, Option
             }
             
             responseData = data
-            print("Fetched data: \(data)")
-            print("Fetched response: \(String(describing: response))")
             semaphore.signal()
         }
         

--- a/Sources/MapboxDirectionsCLI/CodingOperation.swift
+++ b/Sources/MapboxDirectionsCLI/CodingOperation.swift
@@ -121,21 +121,15 @@ class CodingOperation<ResponseType : Codable & DirectionsResultsProvider, Option
         return interpolatedCoordinates
     }
     
-    private func requestResponse(_ coordinates: [Waypoint]?) -> (Data?, Data) {
+    private func requestResponse(_ coordinates: [Waypoint]?, includesSteps: Bool?) -> (Data?, Data) {
         let semaphore = DispatchSemaphore(value: 0)
         
-        var waypoints: [Waypoint]
-        if coordinates != nil {
-            waypoints = coordinates!
-        } else {
-            waypoints = [
-                Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.9131752, longitude: -77.0324047), name: "Mapbox"),
-                Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.8977, longitude: -77.0365), name: "White House"),
-            ]
-        }
+        guard let waypoints = coordinates, let includesSteps = includesSteps else {
+            print("Failed to request response without coordinates.")
+            exit(1) }
         
         let options = RouteOptions(waypoints: waypoints, profileIdentifier: .automobileAvoidingTraffic)
-        options.includesSteps = true
+        options.includesSteps = includesSteps
         var responseData: Data?
         
         let url = directions.url(forCalculating: options)
@@ -178,7 +172,7 @@ class CodingOperation<ResponseType : Codable & DirectionsResultsProvider, Option
         if let inputPath = options.inputPath {
             input = FileManager.default.contents(atPath: NSString(string: inputPath).expandingTildeInPath)!
         } else {
-            let response = requestResponse(directionsOptions.waypoints)
+            let response = requestResponse(directionsOptions.waypoints, includesSteps: directionsOptions.includesSteps)
             input = response.0
         }
         

--- a/Sources/MapboxDirectionsCLI/CodingOperation.swift
+++ b/Sources/MapboxDirectionsCLI/CodingOperation.swift
@@ -4,6 +4,9 @@ import Turf
 import CoreLocation
 
 private let BogusCredentials = Credentials(accessToken: "pk.feedCafeDadeDeadBeef-BadeBede.FadeCafeDadeDeed-BadeBede")
+let accessToken = ProcessInfo.processInfo.environment["access_token"]
+let credentials = DirectionsCredentials(accessToken: accessToken)
+private let directions = Directions(credentials: credentials)
 
 protocol DirectionsResultsProvider {
     var directionsResults: [DirectionsResult]? { get }
@@ -181,7 +184,7 @@ class CodingOperation<ResponseType : Codable & DirectionsResultsProvider, Option
         }
         
         decoder.userInfo = [.options: directionsOptions,
-                            .credentials: NotBogusCredentials]
+                            .credentials: credentials]
         
         let (data, directionsResultsProvider) = try processResponse(decoder, from: input)
         

--- a/Sources/MapboxDirectionsCLI/CodingOperation.swift
+++ b/Sources/MapboxDirectionsCLI/CodingOperation.swift
@@ -130,6 +130,12 @@ class CodingOperation<ResponseType : Codable & DirectionsResultsProvider, Option
         
         let options = RouteOptions(waypoints: waypoints, profileIdentifier: .automobileAvoidingTraffic)
         options.includesSteps = includesSteps
+        options.allowsUTurnAtWaypoint = true
+        options.includesAlternativeRoutes = false
+        options.includesExitRoundaboutManeuver = true
+        options.roadClassesToAvoid = []
+        options.routeShapeResolution = .full
+        
         var responseData: Data?
         
         let url = directions.url(forCalculating: options)

--- a/Sources/MapboxDirectionsCLI/CodingOperation.swift
+++ b/Sources/MapboxDirectionsCLI/CodingOperation.swift
@@ -1,7 +1,6 @@
 import Foundation
 import MapboxDirections
 import Turf
-import CoreLocation
 
 let accessToken: String? =
     ProcessInfo.processInfo.environment["MAPBOX_ACCESS_TOKEN"] ??

--- a/Sources/MapboxDirectionsCLI/CodingOperation.swift
+++ b/Sources/MapboxDirectionsCLI/CodingOperation.swift
@@ -6,7 +6,7 @@ import CoreLocation
 let accessToken: String? =
     ProcessInfo.processInfo.environment["MAPBOX_ACCESS_TOKEN"] ??
     UserDefaults.standard.string(forKey: "MBXAccessToken")
-let credentials = DirectionsCredentials(accessToken: accessToken!)
+let credentials = Credentials(accessToken: accessToken!)
 private let directions = Directions(credentials: credentials)
 
 protocol DirectionsResultsProvider {

--- a/Sources/MapboxDirectionsCLI/CodingOperation.swift
+++ b/Sources/MapboxDirectionsCLI/CodingOperation.swift
@@ -1,6 +1,9 @@
 import Foundation
 import MapboxDirections
 import Turf
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 let accessToken: String? =
     ProcessInfo.processInfo.environment["MAPBOX_ACCESS_TOKEN"] ??

--- a/Sources/MapboxDirectionsCLI/CodingOperation.swift
+++ b/Sources/MapboxDirectionsCLI/CodingOperation.swift
@@ -1,7 +1,9 @@
 import Foundation
 import MapboxDirections
 import Turf
+#if canImport(CoreLocation)
 import CoreLocation
+#endif
 
 private let BogusCredentials = Credentials(accessToken: "pk.feedCafeDadeDeadBeef-BadeBede.FadeCafeDadeDeed-BadeBede")
 

--- a/Sources/MapboxDirectionsCLI/CodingOperation.swift
+++ b/Sources/MapboxDirectionsCLI/CodingOperation.swift
@@ -1,9 +1,7 @@
 import Foundation
 import MapboxDirections
 import Turf
-#if canImport(CoreLocation)
 import CoreLocation
-#endif
 
 private let BogusCredentials = Credentials(accessToken: "pk.feedCafeDadeDeadBeef-BadeBede.FadeCafeDadeDeed-BadeBede")
 

--- a/Sources/MapboxDirectionsCLI/CodingOperation.swift
+++ b/Sources/MapboxDirectionsCLI/CodingOperation.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MapboxDirections
 import Turf
+import CoreLocation
 
 private let BogusCredentials = Credentials(accessToken: "pk.feedCafeDadeDeadBeef-BadeBede.FadeCafeDadeDeed-BadeBede")
 

--- a/Sources/MapboxDirectionsCLI/main.swift
+++ b/Sources/MapboxDirectionsCLI/main.swift
@@ -7,7 +7,7 @@ import ArgumentParser
 
 struct ProcessingOptions: ParsableArguments {
     
-    @Option(name: [.short, .customLong("input")], help: "Filepath to the input JSON.")
+    @Option(name: [.short, .customLong("input")], help: "[Optional] Filepath to the input JSON. If no filepath provided - will fall back to Directions API request.")
     var inputPath: String
     
     @Option(name: [.short, .customLong("config")], help: "Filepath to the JSON, containing serialized Options data.")

--- a/Sources/MapboxDirectionsCLI/main.swift
+++ b/Sources/MapboxDirectionsCLI/main.swift
@@ -7,8 +7,8 @@ import ArgumentParser
 
 struct ProcessingOptions: ParsableArguments {
     
-    @Option(name: [.short, .customLong("input")], help: "[Optional] Filepath to the input JSON. If no filepath provided - will fall back to Directions API request.")
-    var inputPath: String
+    @Option(name: [.short, .customLong("input")], help: "[Optional] Filepath to the input JSON. If no filepath provided - will fall back to Directions API request using locations in config file.")
+    var inputPath: String?
     
     @Option(name: [.short, .customLong("config")], help: "Filepath to the JSON, containing serialized Options data.")
     var configPath: String
@@ -34,9 +34,6 @@ struct Command: ParsableCommand {
     )
     
     fileprivate static func validateInput(_ options: ProcessingOptions) throws {
-        guard FileManager.default.fileExists(atPath: options.inputPath) else {
-            throw ValidationError("Input JSON file `\(options.inputPath)` does not exist.")
-        }
         
         guard FileManager.default.fileExists(atPath: options.configPath) else {
             throw ValidationError("Options JSON file `\(options.configPath)` does not exist.")


### PR DESCRIPTION
Fixes #570.

Currently rebased on top of the gpx output enhancement for testing. Can be merged after gpx output PR is merged.