### PR TITLE
Waypoint snapping to a closed road

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * `RouteOptions.alleyPriority`, `RouteOptions.walkwayPriority`, and `RouteOptions.speed` are now optional. Set them explicitly if you want to include them in the HTTP request. Renamed `DirectionsOptions.default` to `DirectionsOptions.medium`. ([#557](https://github.com/mapbox/mapbox-directions-swift/pull/557))
 * Removed the `DirectionsResult.routeIdentifier` property. Use the `RouteResponse.identifier` property in conjunction with an index into the `RouteResponse.routes` array instead. ([#562](https://github.com/mapbox/mapbox-directions-swift/pull/562))
 * Fixed an issue where RouteStep.exitIndex was always unset. ([#567](https://github.com/mapbox/mapbox-directions-swift/pull/567))
+* Added `Waypoint.allowsSnappingToClosedRoad` property to allow snapping waypoint location to closed parts of the road. ([#583](https://github.com/mapbox/mapbox-directions-swift/pull/583))
 
 ## v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * `RouteOptions.alleyPriority`, `RouteOptions.walkwayPriority`, and `RouteOptions.speed` are now optional. Set them explicitly if you want to include them in the HTTP request. Renamed `DirectionsOptions.default` to `DirectionsOptions.medium`. ([#557](https://github.com/mapbox/mapbox-directions-swift/pull/557))
 * Removed the `DirectionsResult.routeIdentifier` property. Use the `RouteResponse.identifier` property in conjunction with an index into the `RouteResponse.routes` array instead. ([#562](https://github.com/mapbox/mapbox-directions-swift/pull/562))
 * Fixed an issue where RouteStep.exitIndex was always unset. ([#567](https://github.com/mapbox/mapbox-directions-swift/pull/567))
-* Added `Waypoint.allowsSnappingToClosedRoad` property to allow snapping waypoint location to closed parts of the road. ([#583](https://github.com/mapbox/mapbox-directions-swift/pull/583))
+* Added the `Waypoint.allowsSnappingToClosedRoad` property to allow snapping the waypoint’s location to a closed part of a road. ([#583](https://github.com/mapbox/mapbox-directions-swift/pull/583))
 
 ## v1.2.0
 

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -362,6 +362,10 @@ open class DirectionsOptions: Codable {
             queryItems.append(URLQueryItem(name: "waypoint_names", value: names))
         }
         
+        if let snapping = self.closureSnapping {
+            queryItems.append(URLQueryItem(name: "snapping_include_closures", value: snapping))
+        }
+        
         return queryItems
     }
     
@@ -420,6 +424,13 @@ open class DirectionsOptions: Codable {
     
     internal var coordinates: String? {
         return waypoints.map { $0.coordinate.requestDescription }.joined(separator: ";")
+    }
+    
+    internal var closureSnapping: String? {
+        guard waypoints.contains(where: \.allowsSnappingToClosedRoad) else {
+            return nil
+        }
+        return waypoints.map { $0.allowsSnappingToClosedRoad ? "true": ""}.joined(separator: ";")
     }
 
     internal var httpBody: String {

--- a/Sources/MapboxDirections/Waypoint.swift
+++ b/Sources/MapboxDirections/Waypoint.swift
@@ -146,9 +146,9 @@ public class Waypoint: Codable {
     public var targetCoordinate: LocationCoordinate2D?
     
     /**
-     Affects snapping of waypoint location to road segments.
+     A Boolean value indicating whether the waypoint may be snapped to a closed road in the resulting `RouteResponse`.
      
-     If `true`, road segments closed due to live-traffic closures will be considered for snapping. Defaults to `false`. This property corresponds to the [`snapping_include_closures`](https://docs.mapbox.com/api/navigation/directions/#optional-parameters-for-the-mapboxdriving-traffic-profile) Directions query parameter.
+     If `true`, the waypoint may be snapped to a road segment that is closed due to a live traffic closure. This property is `false` by default. This property corresponds to the [`snapping_include_closures`](https://docs.mapbox.com/api/navigation/directions/#optional-parameters-for-the-mapboxdriving-traffic-profile) query parameter in the Mapbox Directions API.
      */
     public var allowsSnappingToClosedRoad: Bool = false
     

--- a/Sources/MapboxDirections/Waypoint.swift
+++ b/Sources/MapboxDirections/Waypoint.swift
@@ -145,6 +145,13 @@ public class Waypoint: Codable {
      */
     public var targetCoordinate: LocationCoordinate2D?
     
+    /**
+     Affects snapping of waypoint location to road segments.
+     
+     If `true`, road segments closed due to live-traffic closures will be considered for snapping. Defaults to `false`. This property corresponds to the [`snapping_include_closures`](https://docs.mapbox.com/api/navigation/directions/#optional-parameters-for-the-mapboxdriving-traffic-profile) Directions query parameter.
+     */
+    public var allowsSnappingToClosedRoad: Bool = false
+    
     // MARK: Getting the Direction of Approach
     
     /**

--- a/Tests/MapboxDirectionsTests/WaypointTests.swift
+++ b/Tests/MapboxDirectionsTests/WaypointTests.swift
@@ -150,4 +150,18 @@ class WaypointTests: XCTestCase {
         from.coordinateAccuracy = 5
         XCTAssertEqual(options.radiuses, "5.0;unlimited")
     }
+    
+    func testClosedRoadSnapping() {
+        let from = Waypoint(coordinate: LocationCoordinate2D(latitude: 0, longitude: 0))
+        let to = Waypoint(coordinate: LocationCoordinate2D(latitude: 0, longitude: 0))
+        let through = Waypoint(coordinate: LocationCoordinate2D(latitude: 0, longitude: 0))
+        
+        let routeOptions = RouteOptions(waypoints: [from, through, to])
+        let matchOptions = MatchOptions(waypoints: [from, through, to], profileIdentifier: nil)
+        
+        through.allowsSnappingToClosedRoad = true
+        
+        XCTAssertEqual(routeOptions.urlQueryItems.first { $0.name == "snapping_include_closures" }?.value, ";true;")
+        XCTAssertEqual(matchOptions.urlQueryItems.first { $0.name == "snapping_include_closures" }?.value, ";true;")
+    }
 }


### PR DESCRIPTION
Resolves #554 
This PR adds `Waypoint.allowsSnappingToClosedRoad` property and it's serialization to url parameters. Intentionally did not add checks for `profileIdentifier` since property is optional and could be potentially extended to other profiles.