### PR TITLE
Fix segment indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fixed an issue where RouteStep.exitIndex was always unset. ([#567](https://github.com/mapbox/mapbox-directions-swift/pull/567))
 * Added the `Waypoint.allowsSnappingToClosedRoad` property to allow snapping the waypoint’s location to a closed part of a road. ([#583](https://github.com/mapbox/mapbox-directions-swift/pull/583))
 * Added `AttributeOptions.numericCongestionLevel`, `RouteLeg.segmentNumericCongestionLevels`, `RouteLeg.Attributes.segmentNumericCongestionLevels` and `NumericCongestionLevel` to support receiving the numeric value for congestion level along each segment of a `RouteLeg`. ([#575](https://github.com/mapbox/mapbox-directions-swift/pull/575))
+* Fixed an issue where `RouteLeg.segmentRangesByStep` contained a range that was off by one for the arrival step of a leg. ([#587](https://github.com/mapbox/mapbox-directions-swift/pull/587))
 
 ## v1.2.0
 
@@ -52,7 +53,7 @@
 
 ## v0.33.1
 
-* Fixed an issue where `RouteResponse(matching:options:credentials:)` and `Directions.calculateRoutes(matching:completionHandler:)` resulted in misshappen `Route.shape`s and `RouteStep.shape`s in the Atlantic Ocean if `MatchOptions.shapeFormat` was set to `RouteShapeFormat.polyline6`. ([#437](https://github.com/mapbox/mapbox-directions-swift/pull/437)) 
+* Fixed an issue where `RouteResponse(matching:options:credentials:)` and `Directions.calculateRoutes(matching:completionHandler:)` resulted in misshappen `Route.shape`s and `RouteStep.shape`s in the Atlantic Ocean if `MatchOptions.shapeFormat` was set to `RouteShapeFormat.polyline6`. ([#437](https://github.com/mapbox/mapbox-directions-swift/pull/437))
 
 ## v0.33.0
 
@@ -67,7 +68,7 @@
 
 ## v0.31.1
 
-* Fixed an issue where `RouteResponse(matching:options:credentials:)` and `Directions.calculateRoutes(matching:completionHandler:)` resulted in misshappen `Route.shape`s and `RouteStep.shape`s in the Atlantic Ocean if `MatchOptions.shapeFormat` was set to `RouteShapeFormat.polyline6`. ([#437](https://github.com/mapbox/mapbox-directions-swift/pull/437)) 
+* Fixed an issue where `RouteResponse(matching:options:credentials:)` and `Directions.calculateRoutes(matching:completionHandler:)` resulted in misshappen `Route.shape`s and `RouteStep.shape`s in the Atlantic Ocean if `MatchOptions.shapeFormat` was set to `RouteShapeFormat.polyline6`. ([#437](https://github.com/mapbox/mapbox-directions-swift/pull/437))
 
 ## v0.31.0
 
@@ -148,7 +149,7 @@
 * Added the `Waypoint.separatesLegs` property, which you can set to `false` to create a route that travels “via” the waypoint but doesn’t stop there. Deprecated the `MatchOptions.waypointIndices` property in favor of `Waypoint.separatesLegs`, which also works with `RouteOptions`. ([#340](https://github.com/mapbox/mapbox-directions-swift/pull/340))
 * Fixed unset properties in  `Waypoint` objects that are included in a calculated `Route`s or `Match`es. ([#340](https://github.com/mapbox/mapbox-directions-swift/pull/340))
 * Added `DirectionsResult.fetchStartDate` and `DirectionsResult.requestEndDate` properties. ([#335](https://github.com/mapbox/mapbox-directions-swift/pull/335))
-* Added a `DirectionsOptions.urlQueryItems` property so that subclasses of `RouteOptions` and `MatchOptions` can add any additional URL query parameters that are supported by the Mapbox Directions and Map Matching APIs. ([#343](https://github.com/mapbox/mapbox-directions-swift/pull/343)) 
+* Added a `DirectionsOptions.urlQueryItems` property so that subclasses of `RouteOptions` and `MatchOptions` can add any additional URL query parameters that are supported by the Mapbox Directions and Map Matching APIs. ([#343](https://github.com/mapbox/mapbox-directions-swift/pull/343))
 
 ## v0.26.1
 

--- a/Sources/MapboxDirections/RouteLeg.swift
+++ b/Sources/MapboxDirections/RouteLeg.swift
@@ -155,7 +155,7 @@ open class RouteLeg: Codable {
         var currentStepStartIndex = 0
         for step in steps {
             if let coordinates = step.shape?.coordinates {
-                let stepCoordinateCount = step.maneuverType == .arrive ? coordinates.count : coordinates.dropLast().count
+                let stepCoordinateCount = step.maneuverType == .arrive ? 0 : coordinates.dropLast().count
                 let currentStepEndIndex = currentStepStartIndex.advanced(by: stepCoordinateCount)
                 segmentRangesByStep.append(currentStepStartIndex..<currentStepEndIndex)
                 currentStepStartIndex = currentStepEndIndex

--- a/Tests/MapboxDirectionsTests/RouteLegTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteLegTests.swift
@@ -9,6 +9,7 @@ class RouteLegTests: XCTestCase {
             LocationCoordinate2D(latitude: 0, longitude: 0),
             LocationCoordinate2D(latitude: 1, longitude: 1),
         ])
+        let noShapeStep = RouteStep(transportType: .automobile, maneuverLocation: LocationCoordinate2D(latitude: 1, longitude: 1), maneuverType: .continue, instructions: "Continue", drivingSide: .right, distance: 0, expectedTravelTime: 0)
         let turnStep = RouteStep(transportType: .automobile, maneuverLocation: LocationCoordinate2D(latitude: 1, longitude: 1), maneuverType: .turn, maneuverDirection: .left, instructions: "Turn left at Albuquerque", drivingSide: .right, distance: 10, expectedTravelTime: 10)
         turnStep.shape = LineString([
             LocationCoordinate2D(latitude: 1, longitude: 1),
@@ -22,13 +23,13 @@ class RouteLegTests: XCTestCase {
             LocationCoordinate2D(latitude: 4, longitude: 4),
             LocationCoordinate2D(latitude: 4, longitude: 4),
         ])
-        let leg = RouteLeg(steps: [departureStep, turnStep, arrivalStep], name: "", distance: 10, expectedTravelTime: 10, typicalTravelTime: typicalTravelTime, profileIdentifier: .automobile)
+        let leg = RouteLeg(steps: [departureStep, noShapeStep, turnStep, arrivalStep], name: "", distance: 10, expectedTravelTime: 10, typicalTravelTime: typicalTravelTime, profileIdentifier: .automobile)
         leg.segmentDistances = [
             10,
             10, 20, 30,
         ]
         XCTAssertEqual(leg.segmentRangesByStep.count, leg.steps.count)
-        XCTAssertEqual(leg.segmentRangesByStep, [0..<1, 1..<4, 4..<4])
+        XCTAssertEqual(leg.segmentRangesByStep, [0..<1, 1..<1, 1..<4, 4..<4])
         XCTAssertEqual(leg.segmentRangesByStep.last?.upperBound, leg.segmentDistances?.count)
         XCTAssertEqual(leg.typicalTravelTime, typicalTravelTime)
     }

--- a/Tests/MapboxDirectionsTests/RouteLegTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteLegTests.swift
@@ -18,6 +18,10 @@ class RouteLegTests: XCTestCase {
         ])
         let typicalTravelTime = 10.0
         let arrivalStep = RouteStep(transportType: .automobile, maneuverLocation: LocationCoordinate2D(latitude: 4, longitude: 4), maneuverType: .arrive, instructions: "Arrive at Elmer’s House", drivingSide: .right, distance: 0, expectedTravelTime: 0)
+        arrivalStep.shape = LineString([
+            LocationCoordinate2D(latitude: 4, longitude: 4),
+            LocationCoordinate2D(latitude: 4, longitude: 4),
+        ])
         let leg = RouteLeg(steps: [departureStep, turnStep, arrivalStep], name: "", distance: 10, expectedTravelTime: 10, typicalTravelTime: typicalTravelTime, profileIdentifier: .automobile)
         leg.segmentDistances = [
             10,


### PR DESCRIPTION
There was an issue with `segmentRangesByStep` having the wrong range for the arrival step. Instead of being empty, it had the length of 2 as the arrival step in real responses has a geometry that is a line with the same two points (zero-length line).

cc: @1ec5 