### PR TITLE
Raw coding keys for DirectionsOptions and its subclasses match the query parameter names

### DIFF
--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -132,14 +132,14 @@ open class DirectionsOptions: Codable {
     private enum CodingKeys: String, CodingKey {
         case waypoints
         case profileIdentifier
-        case includesSteps
+        case includesSteps = "steps"
         case shapeFormat
         case routeShapeResolution
         case attributeOptions
         case locale
-        case includesSpokenInstructions
+        case includesSpokenInstructions = "voice_instructions"
         case distanceMeasurementSystem
-        case includesVisualInstructions
+        case includesVisualInstructions = "banner_instructions"
     }
     
     public func encode(to encoder: Encoder) throws {

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -131,14 +131,14 @@ open class DirectionsOptions: Codable {
     
     private enum CodingKeys: String, CodingKey {
         case waypoints
-        case profileIdentifier
+        case profileIdentifier = "profile"
         case includesSteps = "steps"
-        case shapeFormat
-        case routeShapeResolution
-        case attributeOptions
-        case locale
+        case shapeFormat = "geometries"
+        case routeShapeResolution = "overview"
+        case attributeOptions = "annotations"
+        case locale = "language"
         case includesSpokenInstructions = "voice_instructions"
-        case distanceMeasurementSystem
+        case distanceMeasurementSystem = "voice_units"
         case includesVisualInstructions = "banner_instructions"
     }
     

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -51,11 +51,11 @@ open class RouteOptions: DirectionsOptions {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case allowsUTurnAtWaypoint
-        case includesAlternativeRoutes
-        case includesExitRoundaboutManeuver
-        case roadClassesToAvoid
-        case refreshingEnabled
+        case allowsUTurnAtWaypoint = "continue_straight"
+        case includesAlternativeRoutes = "alternatives"
+        case includesExitRoundaboutManeuver = "roundabout_exits"
+        case roadClassesToAvoid = "exclude"
+        case refreshingEnabled = "enable_refresh"
     }
     
     public override func encode(to encoder: Encoder) throws {

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -73,6 +73,27 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertEqual(routeOptions.includesExitRoundaboutManeuver, true)
         XCTAssertEqual(routeOptions.roadClassesToAvoid, .toll)
         XCTAssertEqual(routeOptions.refreshingEnabled, false)
+        
+        let encodedRouteOptions: Data = try! JSONEncoder().encode(routeOptions)
+        let optionsString: String = String(data: encodedRouteOptions, encoding: .utf8)!
+        
+        let unarchivedOptions: RouteOptions = try! JSONDecoder().decode(RouteOptions.self, from: optionsString.data(using: .utf8)!)
+        
+        XCTAssertNotNil(unarchivedOptions)
+        XCTAssertEqual(unarchivedOptions.profileIdentifier, routeOptions.profileIdentifier)
+        XCTAssertEqual(unarchivedOptions.includesSteps, routeOptions.includesSteps)
+        XCTAssertEqual(unarchivedOptions.shapeFormat, routeOptions.shapeFormat)
+        XCTAssertEqual(unarchivedOptions.routeShapeResolution, routeOptions.routeShapeResolution)
+        XCTAssertEqual(unarchivedOptions.attributeOptions, routeOptions.attributeOptions)
+        XCTAssertEqual(unarchivedOptions.locale, routeOptions.locale)
+        XCTAssertEqual(unarchivedOptions.includesSpokenInstructions, routeOptions.includesSpokenInstructions)
+        XCTAssertEqual(unarchivedOptions.distanceMeasurementSystem, routeOptions.distanceMeasurementSystem)
+        XCTAssertEqual(unarchivedOptions.includesVisualInstructions, routeOptions.includesVisualInstructions)
+        XCTAssertEqual(unarchivedOptions.allowsUTurnAtWaypoint, routeOptions.allowsUTurnAtWaypoint)
+        XCTAssertEqual(unarchivedOptions.includesAlternativeRoutes, routeOptions.includesAlternativeRoutes)
+        XCTAssertEqual(unarchivedOptions.includesExitRoundaboutManeuver, routeOptions.includesExitRoundaboutManeuver)
+        XCTAssertEqual(unarchivedOptions.roadClassesToAvoid, routeOptions.roadClassesToAvoid)
+        XCTAssertEqual(unarchivedOptions.refreshingEnabled, routeOptions.refreshingEnabled)
     }
     
     // MARK: API name-handling tests

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -31,6 +31,50 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertEqual(unarchivedOptions.roadClassesToAvoid, options.roadClassesToAvoid)
     }
     
+    func testCodingWithRawCodingKeys() {
+        let routeOptionsJSON: [String: Any?] = [
+            "waypoints": [
+                [
+                "location": [-77.036500000000004, 38.8977],
+                "name": "White House",
+                ]
+            ],
+            "profile": "mapbox/driving-traffic",
+            "steps": true,
+            "geometries": "polyline",
+            "overview": "simplified",
+            "annotations": ["congestion"],
+            "language": "en_US",
+            "voice_instructions": true,
+            "voice_units": "imperial",
+            "banner_instructions": true,
+            "continue_straight": true,
+            "alternatives": false,
+            "roundabout_exits": true,
+            "exclude": ["toll"],
+            "enable_refresh": false
+        ]
+        
+        let routeOptionsData = try! JSONSerialization.data(withJSONObject: routeOptionsJSON, options: [])
+        var routeOptions: RouteOptions?
+        XCTAssertNoThrow(routeOptions = try JSONDecoder().decode(RouteOptions.self, from: routeOptionsData))
+        
+        XCTAssertEqual(routeOptions?.profileIdentifier, .automobileAvoidingTraffic)
+        XCTAssertEqual(routeOptions?.includesSteps, true)
+        XCTAssertEqual(routeOptions?.shapeFormat, .polyline)
+        XCTAssertEqual(routeOptions?.routeShapeResolution, .low)
+        XCTAssertEqual(routeOptions?.attributeOptions, .congestionLevel)
+        XCTAssertEqual(routeOptions?.locale, Locale(identifier: "en_US"))
+        XCTAssertEqual(routeOptions?.includesSpokenInstructions, true)
+        XCTAssertEqual(routeOptions?.distanceMeasurementSystem, .imperial)
+        XCTAssertEqual(routeOptions?.includesVisualInstructions, true)
+        XCTAssertEqual(routeOptions?.allowsUTurnAtWaypoint, true)
+        XCTAssertEqual(routeOptions?.includesAlternativeRoutes, false)
+        XCTAssertEqual(routeOptions?.includesExitRoundaboutManeuver, true)
+        XCTAssertEqual(routeOptions?.roadClassesToAvoid, .toll)
+        XCTAssertEqual(routeOptions?.refreshingEnabled, false)
+    }
+    
     // MARK: API name-handling tests
     
     private static var testWaypoints: [Waypoint] {

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -56,23 +56,23 @@ class RouteOptionsTests: XCTestCase {
         ]
         
         let routeOptionsData = try! JSONSerialization.data(withJSONObject: routeOptionsJSON, options: [])
-        var routeOptions: RouteOptions?
-        XCTAssertNoThrow(routeOptions = try JSONDecoder().decode(RouteOptions.self, from: routeOptionsData))
+        var routeOptions: RouteOptions!
+        XCTAssertNoThrow(routeOptions = try! JSONDecoder().decode(RouteOptions.self, from: routeOptionsData))
         
-        XCTAssertEqual(routeOptions?.profileIdentifier, .automobileAvoidingTraffic)
-        XCTAssertEqual(routeOptions?.includesSteps, true)
-        XCTAssertEqual(routeOptions?.shapeFormat, .polyline)
-        XCTAssertEqual(routeOptions?.routeShapeResolution, .low)
-        XCTAssertEqual(routeOptions?.attributeOptions, .congestionLevel)
-        XCTAssertEqual(routeOptions?.locale, Locale(identifier: "en_US"))
-        XCTAssertEqual(routeOptions?.includesSpokenInstructions, true)
-        XCTAssertEqual(routeOptions?.distanceMeasurementSystem, .imperial)
-        XCTAssertEqual(routeOptions?.includesVisualInstructions, true)
-        XCTAssertEqual(routeOptions?.allowsUTurnAtWaypoint, true)
-        XCTAssertEqual(routeOptions?.includesAlternativeRoutes, false)
-        XCTAssertEqual(routeOptions?.includesExitRoundaboutManeuver, true)
-        XCTAssertEqual(routeOptions?.roadClassesToAvoid, .toll)
-        XCTAssertEqual(routeOptions?.refreshingEnabled, false)
+        XCTAssertEqual(routeOptions.profileIdentifier, .automobileAvoidingTraffic)
+        XCTAssertEqual(routeOptions.includesSteps, true)
+        XCTAssertEqual(routeOptions.shapeFormat, .polyline)
+        XCTAssertEqual(routeOptions.routeShapeResolution, .low)
+        XCTAssertEqual(routeOptions.attributeOptions, .congestionLevel)
+        XCTAssertEqual(routeOptions.locale, Locale(identifier: "en_US"))
+        XCTAssertEqual(routeOptions.includesSpokenInstructions, true)
+        XCTAssertEqual(routeOptions.distanceMeasurementSystem, .imperial)
+        XCTAssertEqual(routeOptions.includesVisualInstructions, true)
+        XCTAssertEqual(routeOptions.allowsUTurnAtWaypoint, true)
+        XCTAssertEqual(routeOptions.includesAlternativeRoutes, false)
+        XCTAssertEqual(routeOptions.includesExitRoundaboutManeuver, true)
+        XCTAssertEqual(routeOptions.roadClassesToAvoid, .toll)
+        XCTAssertEqual(routeOptions.refreshingEnabled, false)
     }
     
     // MARK: API name-handling tests


### PR DESCRIPTION
Fixes #581 by adding raw coding keys for DirectionsOptions and RouteOptions and the corresponding tests. MatchOptions already had raw coding keys, so this class was not changed.