### PR TITLE
Migrate Carthage-based builds back to jakeheis/SwiftCLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * To gain access to the Mapbox Directions and Map Matching APIs, set `MBXAccessToken` in your Info.plist. `MGLMapboxAccessToken` is still supported but is now deprecated. ([#522](https://github.com/mapbox/mapbox-directions-swift/pull/522))
 * This library requires Turf v2.0.0-rc.1. ([#571](https://github.com/mapbox/mapbox-directions-swift/pull/571))
+* If you install the `mapbox-directions-swift` command line tool using Carthage, it now requires [SwiftCLI](https://github.com/jakeheis/SwiftCLI/) v6.0.3 and above. ([#599](https://github.com/mapbox/mapbox-directions-swift/pull/599))
 * The `Incident.impact` property is now an `Incident.Impact` value instead of a string. ([#519](https://github.com/mapbox/mapbox-directions-swift/pull/519))
 * Added the `Intersection.preferredApproachLanes` and `Intersection.usableLaneIndication` properties that indicate preferred lane usage. `VisualInstruction.Component.lane(indications:isUsable:)` has been renamed to `VisualInstruction.Component.lane(indications:isUsable:preferredDirection:)`. ([#529](https://github.com/mapbox/mapbox-directions-swift/pull/529))
 * Comparing two `Intersection`s with `==` now considers whether the `Intersection.restStop`, `Intersection.regionCode`, and `Intersection.outletMapboxStreetsRoadClass` properties are equal. ([#529](https://github.com/mapbox/mapbox-directions-swift/pull/529))

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "raphaelmor/Polyline" ~> 5.0
 github "mapbox/turf-swift" "v2.0.0-rc.1"
-github "Udumft/SwiftCLI" "carthage-fix"
+github "jakeheis/SwiftCLI" ~> 6.0.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "AliSoftware/OHHTTPStubs" "9.1.0"
-github "Udumft/SwiftCLI" "da19d2a16cd5aa838d8fb7256e28c171bc67dd82"
+github "jakeheis/SwiftCLI" "6.0.3"
 github "mapbox/mapbox-events-ios" "v0.10.8"
 github "mapbox/turf-swift" "v2.0.0-rc.1"
 github "raphaelmor/Polyline" "v5.0.2"


### PR DESCRIPTION
Migrated Carthage-based builds back to jakeheis/SwiftCLI, now that jakeheis/SwiftCLI#100 has been merged.

/cc @mapbox/navigation-ios