### PR TITLE
Fixes the link to API reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ v0.30.0 is the last release of MapboxDirections.swift that supports a minimum de
 
 You’ll need a [Mapbox access token](https://docs.mapbox.com/api/#access-tokens-and-token-scopes) in order to use the API. If you’re already using the [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/), Mapbox Directions automatically recognizes your access token, as long as you’ve placed it in the `MBXAccessToken` key of your application’s Info.plist file.
 
-The examples below are each provided in Swift (denoted with `main.swift`), For further details, see the [Mapbox Directions for Swift API reference](https://docs.mapbox.com/ios/api/directions/).
+The examples below are each provided in Swift (denoted with `main.swift`), For further details, see the [Mapbox Directions for Swift API reference](https://docs.mapbox.com/ios/directions/api/2.0.0-rc.3/).
 
 ### Calculating directions between locations
 


### PR DESCRIPTION
To be changed to https://docs.mapbox.com/ios/directions/api
after this URL will redirect to the latest version.
