### PR TITLE
Swift Argument Parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * To gain access to the Mapbox Directions and Map Matching APIs, set `MBXAccessToken` in your Info.plist. `MGLMapboxAccessToken` is still supported but is now deprecated. ([#522](https://github.com/mapbox/mapbox-directions-swift/pull/522))
 * This library requires Turf v2.0.0-rc.1. ([#571](https://github.com/mapbox/mapbox-directions-swift/pull/571))
-* If you install the `mapbox-directions-swift` command line tool using Carthage, it now requires [SwiftCLI](https://github.com/jakeheis/SwiftCLI/) v6.0.3 and above. ([#599](https://github.com/mapbox/mapbox-directions-swift/pull/599))
+* `mapbox-directions-swift` no longer supports Carthage build. It now requires [swift-argument-parser](https://github.com/apple/swift-argument-parser) v1.0.0 or above. ([#606](https://github.com/mapbox/mapbox-directions-swift/pull/606))
 * The `Incident.impact` property is now an `Incident.Impact` value instead of a string. ([#519](https://github.com/mapbox/mapbox-directions-swift/pull/519))
 * Added the `Intersection.preferredApproachLanes` and `Intersection.usableLaneIndication` properties that indicate preferred lane usage. `VisualInstruction.Component.lane(indications:isUsable:)` has been renamed to `VisualInstruction.Component.lane(indications:isUsable:preferredDirection:)`. ([#529](https://github.com/mapbox/mapbox-directions-swift/pull/529))
 * Comparing two `Intersection`s with `==` now considers whether the `Intersection.restStop`, `Intersection.regionCode`, and `Intersection.outletMapboxStreetsRoadClass` properties are equal. ([#529](https://github.com/mapbox/mapbox-directions-swift/pull/529))

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "raphaelmor/Polyline" ~> 5.0
 github "mapbox/turf-swift" "v2.0.0-rc.1"
-github "jakeheis/SwiftCLI" ~> 6.0.3
+github "apple/swift-argument-parser" ~> 1.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "AliSoftware/OHHTTPStubs" "9.1.0"
-github "jakeheis/SwiftCLI" "6.0.3"
-github "mapbox/mapbox-events-ios" "v0.10.8"
+github "apple/swift-argument-parser" "1.0.1"
+github "mapbox/mapbox-events-ios" "v0.10.12"
 github "mapbox/turf-swift" "v2.0.0-rc.1"
 github "raphaelmor/Polyline" "v5.0.2"

--- a/Package.resolved
+++ b/Package.resolved
@@ -20,12 +20,12 @@
         }
       },
       {
-        "package": "SwiftCLI",
-        "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "2816678bcc37f4833d32abeddbdf5e757fa891d8",
-          "version": "6.0.2"
+          "revision": "d2930e8fcf9c33162b9fcc1d522bc975e2d4179b",
+          "version": "1.0.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "555458bd67acce7322c513ddd3647c9a904f4197",
-          "version": "2.0.0-rc.1"
+          "revision": "007896bb945432d4683e114fcf2f089edff4ceeb",
+          "version": "2.0.0-rc.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/raphaelmor/Polyline.git", from: "5.0.2"),
         .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.0.0-rc.1"),
-        .package(url: "https://github.com/jakeheis/SwiftCLI", from: "6.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs", from: "9.1.0")
     ],
     targets: [
@@ -44,6 +44,9 @@ let package = Package(
             ]),
         .target(
             name: "MapboxDirectionsCLI",
-            dependencies: ["MapboxDirections", "SwiftCLI"]),
+            dependencies: [
+                "MapboxDirections",
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ]),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -208,13 +208,7 @@ The [Mapbox Navigation SDK for iOS](https://github.com/mapbox/mapbox-navigation-
 
 ## Directions CLI
 
-`MapboxDirectionsCLI` is a command line tool, designed to round-trip an arbitrary, JSON-formatted Directions or Map Matching API response through model objects and back to JSON. This is useful for various scenarios including testing purposes and designing more sophisticated API response processing pipelines. It is also supplied as a Swift package.
-
-To build `MapboxDirectionsCLI` using Carthage pipeline:
-
-1. `carthage bootstrap --platform macos --use-xcframeworks`
-1. `open MapboxDirections.xcodeproj`
-1. Select `MapboxDirectionsCLI` target.
+`MapboxDirectionsCLI` is a command line tool, designed to round-trip an arbitrary, JSON-formatted Directions or Map Matching API response through model objects and back to JSON. This is useful for various scenarios including testing purposes and designing more sophisticated API response processing pipelines. It is supplied as a Swift package.
 
 To build `MapboxDirectionsCLI` using SPM:
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,10 @@ The [Mapbox Navigation SDK for iOS](https://github.com/mapbox/mapbox-navigation-
 To build `MapboxDirectionsCLI` using SPM:
 
 1. `swift build`
-1. `swift run MapboxDirectionsCLI -h` to see usage.
+
+To run (and build if it wasn't yet) `MapboxDirectionsCLI` and see usage:
+
+1. `swift run mapbox-directions-swift -h`
 
 ## Pricing
 

--- a/Sources/MapboxDirectionsCLI/main.swift
+++ b/Sources/MapboxDirectionsCLI/main.swift
@@ -34,11 +34,11 @@ struct Command: ParsableCommand {
     
     fileprivate static func validateInput(_ options: ProcessingOptions) throws {
         guard FileManager.default.fileExists(atPath: options.inputPath) else {
-            throw ValidationError("Input JSON file `\(options.inputPath)`does not exist.")
+            throw ValidationError("Input JSON file `\(options.inputPath)` does not exist.")
         }
         
         guard FileManager.default.fileExists(atPath: options.configPath) else {
-            throw ValidationError("Options JSON file `\(options.configPath)`does not exist.")
+            throw ValidationError("Options JSON file `\(options.configPath)` does not exist.")
         }
     }
 }

--- a/Sources/MapboxDirectionsCLI/main.swift
+++ b/Sources/MapboxDirectionsCLI/main.swift
@@ -2,14 +2,65 @@
 
 import Foundation
 import MapboxDirections
-import SwiftCLI
+import ArgumentParser
 
 
-let match = ProcessCommand< MapMatchingResponse, MatchOptions > (name: "match",
-                                                                 shortDescription: "Command to process Map Matching Data")
-let route = ProcessCommand< MapboxDirections.RouteResponse, RouteOptions>(name: "route",
-                                                                          shortDescription: "Command to process Routing Data")
+struct ProcessingOptions: ParsableArguments {
+    
+    @ArgumentParser.Option(name: [.short, .customLong("input")], help: "Filepath to the input JSON.")
+    var inputPath: String?
+    
+    @ArgumentParser.Option(name: [.short, .customLong("config")], help: "Filepath to the JSON, containing serialized Options data.")
+    var configPath: String?
+    
+    @ArgumentParser.Option(name: [.short, .customLong("output")], help: "[Optional] Output filepath to save the conversion result. If no filepath provided - will output to the shell.")
+    var outputPath: String?
+    
+    @ArgumentParser.Option(name: [.customShort("f"), .customLong("format")], help: "Output format. Supports `text` and `json` formats.")
+    var outputFormat: OutputFormat = .text
+    
+    enum OutputFormat: String, ExpressibleByArgument {
+        case text
+        case json
+    }
+}
 
-CLI(name: "mapbox-directions-swift",
-    description: "'mapbox-directions-swift' is a command line tool, designed to round-trip an arbitrary, JSON-formatted Directions or Map Matching API response through model objects and back to JSON.",
-    commands: [route, match]).goAndExit()
+struct Process: ParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "mapbox-directions-swift",
+        abstract: "'mapbox-directions-swift' is a command line tool, designed to round-trip an arbitrary, JSON-formatted Directions or Map Matching API response through model objects and back to JSON.",
+        
+        subcommands: [Match.self, Route.self]
+    )
+}
+
+extension Process {
+    struct Match: ParsableCommand {
+        static var configuration =
+            CommandConfiguration(commandName: "match",
+                                    abstract: "Command to process Map Matching Data.")
+        
+        @ArgumentParser.OptionGroup var options: ProcessingOptions
+        
+        mutating func run() {
+            try? ProcessCommand<MapMatchingResponse, MatchOptions>(options: options).execute()
+        }
+    }
+}
+
+extension Process {
+    struct Route: ParsableCommand {
+        static var configuration =
+                    CommandConfiguration(commandName: "route",
+                                         abstract: "Command to process Routing Data.")
+        
+        @ArgumentParser.OptionGroup var options: ProcessingOptions
+        
+        mutating func run() {
+            try? ProcessCommand<MapboxDirections.RouteResponse, RouteOptions>(options: options).execute()
+        }
+    }
+}
+
+
+Process.main()


### PR DESCRIPTION
Resolves #600 
This PR replaces `jakeheis/SwiftCLI` dependency with `apple/swift-argument-parser`. Updated the source code. Removed Cathage support for `mapbox-directions-swift` since `swift-argument-parser` does not support it.