### PR TITLE
Matrix API Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes to Mapbox Directions for Swift
 
+## v2.9.0
+
+* Added the `RestStop.amenities` property that describes useful and important facilities such as gas stations, restaurants, and ATMs. ([#780](https://github.com/mapbox/mapbox-directions-swift/pull/780))
+* Added `Matrix` API wrapper. The [Mapbox Matrix API](https://docs.mapbox.com/api/navigation/matrix/) computes travel times between many points, and returns a matrix of all travel times between the locations. [#626](https://github.com/mapbox/mapbox-directions-swift/pull/626)
+
 ## v2.8.0
 
 ### Packaging

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -124,6 +124,10 @@
 		2BBBD08E257FA1CD004EB3D6 /* BlockedLanes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BBBD08C257FA1CD004EB3D6 /* BlockedLanes.swift */; };
 		2BBBD08F257FA1CD004EB3D6 /* BlockedLanes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BBBD08C257FA1CD004EB3D6 /* BlockedLanes.swift */; };
 		2BBBD090257FA1CD004EB3D6 /* BlockedLanes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BBBD08C257FA1CD004EB3D6 /* BlockedLanes.swift */; };
+		2BD2553429544D19006C9106 /* URL+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD2553329544D19006C9106 /* URL+Request.swift */; };
+		2BD2553529544D19006C9106 /* URL+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD2553329544D19006C9106 /* URL+Request.swift */; };
+		2BD2553629544D19006C9106 /* URL+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD2553329544D19006C9106 /* URL+Request.swift */; };
+		2BD2553729544D19006C9106 /* URL+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD2553329544D19006C9106 /* URL+Request.swift */; };
 		2BEA240427CFAD2000EE05D9 /* ForeignMemberContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BEA240327CFAD2000EE05D9 /* ForeignMemberContainer.swift */; };
 		2BEA240527CFAD2000EE05D9 /* ForeignMemberContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BEA240327CFAD2000EE05D9 /* ForeignMemberContainer.swift */; };
 		2BEA240627CFAD2000EE05D9 /* ForeignMemberContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BEA240327CFAD2000EE05D9 /* ForeignMemberContainer.swift */; };
@@ -578,6 +582,7 @@
 		2BA98970253F007600B643F6 /* mapbox-directions-swift */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "mapbox-directions-swift"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2BBBD05D257E61ED004EB3D6 /* MapboxStreetsRoadClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxStreetsRoadClass.swift; sourceTree = "<group>"; };
 		2BBBD08C257FA1CD004EB3D6 /* BlockedLanes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanes.swift; sourceTree = "<group>"; };
+		2BD2553329544D19006C9106 /* URL+Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Request.swift"; sourceTree = "<group>"; };
 		2BEA240327CFAD2000EE05D9 /* ForeignMemberContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForeignMemberContainer.swift; sourceTree = "<group>"; };
 		2BF398C427620CD7000C9A72 /* RouteRefreshSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteRefreshSource.swift; sourceTree = "<group>"; };
 		2E44711627C4C80B0041CB84 /* SilentWaypoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SilentWaypoint.swift; sourceTree = "<group>"; };
@@ -840,6 +845,7 @@
 				35DBF00E217E17A30009D2AE /* HTTPURLResponse.swift */,
 				DAE7EA93230B5FD10003B211 /* Measurement.swift */,
 				8D381B691FDB101F008D5A58 /* String.swift */,
+				2BD2553329544D19006C9106 /* URL+Request.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1553,6 +1559,7 @@
 				2B79D3E728E5EB3900B3F127 /* TollPrice.swift in Sources */,
 				431E93CC23466C2500A71B44 /* RouteResponse.swift in Sources */,
 				431E93C423466B0F00A71B44 /* GeoJSON.swift in Sources */,
+				2BD2553529544D19006C9106 /* URL+Request.swift in Sources */,
 				C5990B4A2045E72800D7DFD4 /* DirectionsResult.swift in Sources */,
 				35EFD00C207DFACA00BF3873 /* VisualInstruction.swift in Sources */,
 				C584E3F71F201C7B00BBC9BB /* RoadClasses.swift in Sources */,
@@ -1661,6 +1668,7 @@
 				2B79D3E828E5EB3900B3F127 /* TollPrice.swift in Sources */,
 				431E93CD23466C2700A71B44 /* RouteResponse.swift in Sources */,
 				431E93C523466B1000A71B44 /* GeoJSON.swift in Sources */,
+				2BD2553629544D19006C9106 /* URL+Request.swift in Sources */,
 				C5990B4B2045E72900D7DFD4 /* DirectionsResult.swift in Sources */,
 				35EFD00D207DFACA00BF3873 /* VisualInstruction.swift in Sources */,
 				C584E3F81F201C7C00BBC9BB /* RoadClasses.swift in Sources */,
@@ -1769,6 +1777,7 @@
 				2B79D3E928E5EB3900B3F127 /* TollPrice.swift in Sources */,
 				431E93CE23466C2800A71B44 /* RouteResponse.swift in Sources */,
 				431E93C623466B1100A71B44 /* GeoJSON.swift in Sources */,
+				2BD2553729544D19006C9106 /* URL+Request.swift in Sources */,
 				C5990B4C2045E72A00D7DFD4 /* DirectionsResult.swift in Sources */,
 				35EFD00E207DFACA00BF3873 /* VisualInstruction.swift in Sources */,
 				C584E3F91F201C7D00BBC9BB /* RoadClasses.swift in Sources */,
@@ -1839,6 +1848,7 @@
 				2B79D3E628E5EB3900B3F127 /* TollPrice.swift in Sources */,
 				431E93CB23466C2400A71B44 /* RouteResponse.swift in Sources */,
 				431E93C323466B0E00A71B44 /* GeoJSON.swift in Sources */,
+				2BD2553429544D19006C9106 /* URL+Request.swift in Sources */,
 				35EFD00B207DFACA00BF3873 /* VisualInstruction.swift in Sources */,
 				DAC05F161CFBFAC400FA0071 /* Waypoint.swift in Sources */,
 				C57D55081DB58C0200B94B74 /* Lane.swift in Sources */,

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -9,6 +9,28 @@
 /* Begin PBXBuildFile section */
 		2B01E4B92746ABBC0002A5F7 /* RouteResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3B4C9A24EB55F60085DA64 /* RouteResponseTests.swift */; };
 		2B01E4BA2746ABBD0002A5F7 /* RouteResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3B4C9A24EB55F60085DA64 /* RouteResponseTests.swift */; };
+		2B0BA051294B542900402F81 /* matrix.json in Resources */ = {isa = PBXBuildFile; fileRef = 2B0BA050294B542900402F81 /* matrix.json */; };
+		2B0BA052294B542900402F81 /* matrix.json in Resources */ = {isa = PBXBuildFile; fileRef = 2B0BA050294B542900402F81 /* matrix.json */; };
+		2B0BA053294B542900402F81 /* matrix.json in Resources */ = {isa = PBXBuildFile; fileRef = 2B0BA050294B542900402F81 /* matrix.json */; };
+		2B0BA058294B544E00402F81 /* MatrixOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA054294B544E00402F81 /* MatrixOptions.swift */; };
+		2B0BA059294B544E00402F81 /* MatrixOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA054294B544E00402F81 /* MatrixOptions.swift */; };
+		2B0BA05A294B544E00402F81 /* MatrixOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA054294B544E00402F81 /* MatrixOptions.swift */; };
+		2B0BA05B294B544E00402F81 /* MatrixOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA054294B544E00402F81 /* MatrixOptions.swift */; };
+		2B0BA05C294B544E00402F81 /* MatrixResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA055294B544E00402F81 /* MatrixResponse.swift */; };
+		2B0BA05D294B544E00402F81 /* MatrixResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA055294B544E00402F81 /* MatrixResponse.swift */; };
+		2B0BA05E294B544E00402F81 /* MatrixResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA055294B544E00402F81 /* MatrixResponse.swift */; };
+		2B0BA05F294B544E00402F81 /* MatrixResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA055294B544E00402F81 /* MatrixResponse.swift */; };
+		2B0BA060294B544E00402F81 /* Matrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA056294B544E00402F81 /* Matrix.swift */; };
+		2B0BA061294B544E00402F81 /* Matrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA056294B544E00402F81 /* Matrix.swift */; };
+		2B0BA062294B544E00402F81 /* Matrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA056294B544E00402F81 /* Matrix.swift */; };
+		2B0BA063294B544E00402F81 /* Matrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA056294B544E00402F81 /* Matrix.swift */; };
+		2B0BA064294B544E00402F81 /* MatrixError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA057294B544E00402F81 /* MatrixError.swift */; };
+		2B0BA065294B544E00402F81 /* MatrixError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA057294B544E00402F81 /* MatrixError.swift */; };
+		2B0BA066294B544E00402F81 /* MatrixError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA057294B544E00402F81 /* MatrixError.swift */; };
+		2B0BA067294B544E00402F81 /* MatrixError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA057294B544E00402F81 /* MatrixError.swift */; };
+		2B0BA069294B546300402F81 /* MatrixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA068294B546300402F81 /* MatrixTests.swift */; };
+		2B0BA06A294B546300402F81 /* MatrixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA068294B546300402F81 /* MatrixTests.swift */; };
+		2B0BA06B294B546300402F81 /* MatrixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BA068294B546300402F81 /* MatrixTests.swift */; };
 		2B28E22327EDB2AA0029E4C1 /* ForeignMemberContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B28E22227EDB2A90029E4C1 /* ForeignMemberContainerTests.swift */; };
 		2B28E22427EDB2AA0029E4C1 /* ForeignMemberContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B28E22227EDB2A90029E4C1 /* ForeignMemberContainerTests.swift */; };
 		2B28E22527EDB2AA0029E4C1 /* ForeignMemberContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B28E22227EDB2A90029E4C1 /* ForeignMemberContainerTests.swift */; };
@@ -521,6 +543,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2B0BA050294B542900402F81 /* matrix.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = matrix.json; sourceTree = "<group>"; };
+		2B0BA054294B544E00402F81 /* MatrixOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatrixOptions.swift; sourceTree = "<group>"; };
+		2B0BA055294B544E00402F81 /* MatrixResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatrixResponse.swift; sourceTree = "<group>"; };
+		2B0BA056294B544E00402F81 /* Matrix.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Matrix.swift; sourceTree = "<group>"; };
+		2B0BA057294B544E00402F81 /* MatrixError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatrixError.swift; sourceTree = "<group>"; };
+		2B0BA068294B546300402F81 /* MatrixTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatrixTests.swift; sourceTree = "<group>"; };
 		2B28E22227EDB2A90029E4C1 /* ForeignMemberContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForeignMemberContainerTests.swift; sourceTree = "<group>"; };
 		2B39DD3F270F034700ED68E4 /* CodingOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CodingOperation.swift; path = Sources/MapboxDirectionsCLI/CodingOperation.swift; sourceTree = "<group>"; };
 		2B4383002549C22700A3E38B /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = main.swift; path = Sources/MapboxDirectionsCLI/main.swift; sourceTree = "<group>"; };
@@ -893,6 +921,10 @@
 				DAD06E3823A008EB001A917D /* QuickLook.swift */,
 				C59426061F1EA6C400C8E59C /* RoadClasses.swift */,
 				2BBBD05D257E61ED004EB3D6 /* MapboxStreetsRoadClass.swift */,
+				2B0BA056294B544E00402F81 /* Matrix.swift */,
+				2B0BA057294B544E00402F81 /* MatrixError.swift */,
+				2B0BA054294B544E00402F81 /* MatrixOptions.swift */,
+				2B0BA055294B544E00402F81 /* MatrixResponse.swift */,
 				DAC05F171CFC075300FA0071 /* Route.swift */,
 				DAC05F191CFC077C00FA0071 /* RouteLeg.swift */,
 				2B5407F6245302AB006C820B /* RouteLegAttributes.swift */,
@@ -950,6 +982,7 @@
 				DA8F3A7123B56D3B00B56786 /* RouteLegTests.swift */,
 				DAE9E0F31EB7DE2E001E8E8B /* RouteOptionsTests.swift */,
 				4376A52623FB13D400C6038D /* MatchOptionsTests.swift */,
+				2B0BA068294B546300402F81 /* MatrixTests.swift */,
 				F4D785EE1DDD82C100FF4665 /* RouteStepTests.swift */,
 				DAABF78D2395ABA900CEEB61 /* SpokenInstructionTests.swift */,
 				DA6C9DAB1CAEC72800094FBC /* V5Tests.swift */,
@@ -970,6 +1003,7 @@
 			children = (
 				2B5F0DFB273ACE3B00CC2C1A /* tollAndFerryDirectionsRoute.json */,
 				2BA2E745257A667500D7AFC6 /* incidents.json */,
+				2B0BA050294B542900402F81 /* matrix.json */,
 				8A4741902947D22900F231F9 /* amenities.json */,
 				2B540803245B09B2006C820B /* RouteRefresh */,
 				35DBF017217F387F0009D2AE /* Offline */,
@@ -1352,6 +1386,7 @@
 				2B540801245B097D006C820B /* routeRefreshResponse.json in Resources */,
 				35DBF01A217F38A30009D2AE /* versions.json in Resources */,
 				35D92FF1218203AB000C78CB /* 2018-10-16-Liechtenstein.tar in Resources */,
+				2B0BA052294B542900402F81 /* matrix.json in Resources */,
 				8A4741922947D22900F231F9 /* amenities.json in Resources */,
 				AEAB391220D9469A008F4E54 /* subVisualInstructions.json in Resources */,
 				2B67F68327EDC2EF007BD6D2 /* RouteResponseWithForeignMembers.json in Resources */,
@@ -1390,6 +1425,7 @@
 				2B540802245B097D006C820B /* routeRefreshResponse.json in Resources */,
 				35DBF01B217F38A30009D2AE /* versions.json in Resources */,
 				35D92FF2218203AB000C78CB /* 2018-10-16-Liechtenstein.tar in Resources */,
+				2B0BA053294B542900402F81 /* matrix.json in Resources */,
 				8A4741932947D22900F231F9 /* amenities.json in Resources */,
 				AEAB391320D9469A008F4E54 /* subVisualInstructions.json in Resources */,
 				2B67F68427EDC2EF007BD6D2 /* RouteResponseWithForeignMembers.json in Resources */,
@@ -1435,6 +1471,7 @@
 				2B540800245B097D006C820B /* routeRefreshResponse.json in Resources */,
 				35D92FF0218203AB000C78CB /* 2018-10-16-Liechtenstein.tar in Resources */,
 				AEAB391120D9469A008F4E54 /* subVisualInstructions.json in Resources */,
+				2B0BA051294B542900402F81 /* matrix.json in Resources */,
 				8A4741912947D22900F231F9 /* amenities.json in Resources */,
 				DACCFCA92225359600110FC9 /* v5_driving_oldenburg_polyline.json in Resources */,
 				2B67F68227EDC2EF007BD6D2 /* RouteResponseWithForeignMembers.json in Resources */,
@@ -1503,6 +1540,7 @@
 				8D43467A219E15C3008B7BF3 /* Double.swift in Sources */,
 				C53A02261E92C26E009837BD /* AttributeOptions.swift in Sources */,
 				DA1A10C91D00F969009F82FA /* RouteLeg.swift in Sources */,
+				2B0BA061294B544E00402F81 /* Matrix.swift in Sources */,
 				C52552BA1FA15D5E00B1545C /* VisualInstructionBanner.swift in Sources */,
 				2B46024628EDB1670008A624 /* CustomValueOptionSet.swift in Sources */,
 				8A65DDF72944045F00029C0C /* AmenityType.swift in Sources */,
@@ -1520,9 +1558,11 @@
 				C584E3F71F201C7B00BBC9BB /* RoadClasses.swift in Sources */,
 				C5DAACA220195AB2001F9261 /* MatchOptions.swift in Sources */,
 				43D6617123DBA58E0062BFFE /* (null) in Sources */,
+				2B0BA059294B544E00402F81 /* MatrixOptions.swift in Sources */,
 				2B5407F8245302AB006C820B /* RouteLegAttributes.swift in Sources */,
 				DA1A10CC1D00F969009F82FA /* Waypoint.swift in Sources */,
 				DAD06E3D23A00A01001A917D /* QuickLook.swift in Sources */,
+				2B0BA05D294B544E00402F81 /* MatrixResponse.swift in Sources */,
 				DA1A10CA1D00F969009F82FA /* RouteOptions.swift in Sources */,
 				DA1A10C81D00F969009F82FA /* Route.swift in Sources */,
 				2B5407F32452FA8C006C820B /* RefreshedRoute.swift in Sources */,
@@ -1551,6 +1591,7 @@
 				2BF398C627620CD7000C9A72 /* RouteRefreshSource.swift in Sources */,
 				2B9F3886272AE23A001DBA12 /* IsochroneOptions.swift in Sources */,
 				439255792344113D006EEE88 /* DirectionsError.swift in Sources */,
+				2B0BA065294B544E00402F81 /* MatrixError.swift in Sources */,
 				DA1A10C71D00F969009F82FA /* Directions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1566,6 +1607,7 @@
 				912DF1A7240507640095D3D2 /* TransportTypeTests.swift in Sources */,
 				C53A02291E92C27A009837BD /* AnnotationTests.swift in Sources */,
 				4376A52823FB13D400C6038D /* MatchOptionsTests.swift in Sources */,
+				2B0BA06A294B546300402F81 /* MatrixTests.swift in Sources */,
 				2B01E4B92746ABBC0002A5F7 /* RouteResponseTests.swift in Sources */,
 				DA688B3F21B89ECD00C9BB25 /* VisualInstructionComponentTests.swift in Sources */,
 				2B9F389B272AE28D001DBA12 /* IsochroneTests.swift in Sources */,
@@ -1606,6 +1648,7 @@
 				8D43467B219E15C4008B7BF3 /* Double.swift in Sources */,
 				C53A02271E92C26F009837BD /* AttributeOptions.swift in Sources */,
 				DA1A10EF1D010247009F82FA /* RouteLeg.swift in Sources */,
+				2B0BA062294B544E00402F81 /* Matrix.swift in Sources */,
 				C52552BB1FA15D5F00B1545C /* VisualInstructionBanner.swift in Sources */,
 				2B46024728EDB1670008A624 /* CustomValueOptionSet.swift in Sources */,
 				8A65DDF82944045F00029C0C /* AmenityType.swift in Sources */,
@@ -1623,9 +1666,11 @@
 				C584E3F81F201C7C00BBC9BB /* RoadClasses.swift in Sources */,
 				C5DAACA320195AB2001F9261 /* MatchOptions.swift in Sources */,
 				43D6617223DBA58E0062BFFE /* (null) in Sources */,
+				2B0BA05A294B544E00402F81 /* MatrixOptions.swift in Sources */,
 				2B5407F9245302AB006C820B /* RouteLegAttributes.swift in Sources */,
 				DA1A10F21D010247009F82FA /* Waypoint.swift in Sources */,
 				DAD06E3E23A00A02001A917D /* QuickLook.swift in Sources */,
+				2B0BA05E294B544E00402F81 /* MatrixResponse.swift in Sources */,
 				DA1A10F01D010247009F82FA /* RouteOptions.swift in Sources */,
 				DA1A10EE1D010247009F82FA /* Route.swift in Sources */,
 				2B5407F42452FA8C006C820B /* RefreshedRoute.swift in Sources */,
@@ -1654,6 +1699,7 @@
 				2BF398C727620CD7000C9A72 /* RouteRefreshSource.swift in Sources */,
 				2B9F3887272AE23A001DBA12 /* IsochroneOptions.swift in Sources */,
 				4392557A2344113E006EEE88 /* DirectionsError.swift in Sources */,
+				2B0BA066294B544E00402F81 /* MatrixError.swift in Sources */,
 				DA1A10ED1D010247009F82FA /* Directions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1669,6 +1715,7 @@
 				912DF1A8240507640095D3D2 /* TransportTypeTests.swift in Sources */,
 				C53A022A1E92C27B009837BD /* AnnotationTests.swift in Sources */,
 				4376A52923FB13D400C6038D /* MatchOptionsTests.swift in Sources */,
+				2B0BA06B294B546300402F81 /* MatrixTests.swift in Sources */,
 				2B01E4BA2746ABBD0002A5F7 /* RouteResponseTests.swift in Sources */,
 				DA688B4021B89ECD00C9BB25 /* VisualInstructionComponentTests.swift in Sources */,
 				2B9F389C272AE28E001DBA12 /* IsochroneTests.swift in Sources */,
@@ -1709,6 +1756,7 @@
 				8D43467C219E15C6008B7BF3 /* Double.swift in Sources */,
 				C53A02281E92C271009837BD /* AttributeOptions.swift in Sources */,
 				DA1A11061D0103A3009F82FA /* RouteLeg.swift in Sources */,
+				2B0BA063294B544E00402F81 /* Matrix.swift in Sources */,
 				C52552BC1FA15D6000B1545C /* VisualInstructionBanner.swift in Sources */,
 				2B46024828EDB1670008A624 /* CustomValueOptionSet.swift in Sources */,
 				8A65DDF92944045F00029C0C /* AmenityType.swift in Sources */,
@@ -1726,9 +1774,11 @@
 				C584E3F91F201C7D00BBC9BB /* RoadClasses.swift in Sources */,
 				C5DAACA420195AB3001F9261 /* MatchOptions.swift in Sources */,
 				43D6617323DBA58E0062BFFE /* (null) in Sources */,
+				2B0BA05B294B544E00402F81 /* MatrixOptions.swift in Sources */,
 				2B5407FA245302AB006C820B /* RouteLegAttributes.swift in Sources */,
 				DA1A11091D0103A3009F82FA /* Waypoint.swift in Sources */,
 				DAD06E3F23A00A02001A917D /* QuickLook.swift in Sources */,
+				2B0BA05F294B544E00402F81 /* MatrixResponse.swift in Sources */,
 				DA1A11071D0103A3009F82FA /* RouteOptions.swift in Sources */,
 				DA1A11051D0103A3009F82FA /* Route.swift in Sources */,
 				2B5407F52452FA8C006C820B /* RefreshedRoute.swift in Sources */,
@@ -1757,6 +1807,7 @@
 				2BF398C827620CD7000C9A72 /* RouteRefreshSource.swift in Sources */,
 				2B9F3888272AE23A001DBA12 /* IsochroneOptions.swift in Sources */,
 				4392557B2344113F006EEE88 /* DirectionsError.swift in Sources */,
+				2B0BA067294B544E00402F81 /* MatrixError.swift in Sources */,
 				DA1A11041D0103A3009F82FA /* Directions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1775,6 +1826,7 @@
 				8D434679219E1167008B7BF3 /* Double.swift in Sources */,
 				DA2E03EB1CB0E13D00D1269A /* RouteOptions.swift in Sources */,
 				C582BA2E2073ED6300647DAA /* Array.swift in Sources */,
+				2B0BA060294B544E00402F81 /* Matrix.swift in Sources */,
 				C52552B91FA15D5900B1545C /* VisualInstructionBanner.swift in Sources */,
 				2B46024528EDB1670008A624 /* CustomValueOptionSet.swift in Sources */,
 				8A65DDF62944045F00029C0C /* AmenityType.swift in Sources */,
@@ -1792,9 +1844,11 @@
 				C57D55081DB58C0200B94B74 /* Lane.swift in Sources */,
 				DAC05F181CFC075300FA0071 /* Route.swift in Sources */,
 				43D6617023DBA58E0062BFFE /* (null) in Sources */,
+				2B0BA058294B544E00402F81 /* MatrixOptions.swift in Sources */,
 				2B5407F7245302AB006C820B /* RouteLegAttributes.swift in Sources */,
 				C59094BF203B800300EB2417 /* DirectionsOptions.swift in Sources */,
 				DAD06E3C23A00A01001A917D /* QuickLook.swift in Sources */,
+				2B0BA05C294B544E00402F81 /* MatrixResponse.swift in Sources */,
 				C5434B8C200695A50069E887 /* MatchOptions.swift in Sources */,
 				DAA76D681DD127CB0015EC78 /* LaneIndication.swift in Sources */,
 				2B5407F22452FA8C006C820B /* RefreshedRoute.swift in Sources */,
@@ -1823,6 +1877,7 @@
 				2BF398C527620CD7000C9A72 /* RouteRefreshSource.swift in Sources */,
 				2B9F3885272AE23A001DBA12 /* IsochroneOptions.swift in Sources */,
 				439255772344113B006EEE88 /* DirectionsError.swift in Sources */,
+				2B0BA064294B544E00402F81 /* MatrixError.swift in Sources */,
 				DA2E03E91CB0E0B000D1269A /* RouteStep.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1851,6 +1906,7 @@
 				8A47418F2947D1E100F231F9 /* AmenityTests.swift in Sources */,
 				C5DAACAF201AA92B001F9261 /* MatchTests.swift in Sources */,
 				DA6C9DB21CAECA0E00094FBC /* Fixture.swift in Sources */,
+				2B0BA069294B546300402F81 /* MatrixTests.swift in Sources */,
 				DAE2DF6823AECB120065057A /* QuickLookTests.swift in Sources */,
 				DA1A110B1D01045E009F82FA /* DirectionsTests.swift in Sources */,
 				2B28E22327EDB2AA0029E4C1 /* ForeignMemberContainerTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -210,10 +210,11 @@ let waypoints = [
     Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.755184, longitude: -122.422959), name: "22nd Street"),
     Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.759695, longitude: -122.426911))
 ]
-let matrixOptions = MatrixOptions(waypoints: , profileIdentifier: .automobile)
+let matrixOptions = MatrixOptions(sources: waypoints, destinations: waypoints, profileIdentifier: .automobile)
 matrix.calculate(matrixOptions) { session, result in
-    if case .success(let response) = result {
-        print("Expected route duration from '\(waypoints[0].name)' to '\(waypoints[1].name)' is \(response.travelTime(from:0, to: 1)! / 60) minutes.")
+    if case .success(let response) = result,
+       let expectedTravelTime = response.travelTime(from: 0, to: 1) {
+        print("Expected route duration from '\(waypoints[0].name)' to '\(waypoints[1].name)' is \(expectedTravelTime / 60) minutes.")
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -198,7 +198,25 @@ isochrones.calculate(isochroneOptions) { session, result in
     }
 }
 ```
-...
+
+### Retrieve a distance or duration matrix
+
+See the travel times or distances between many points using the Matrix API. `Matrix` uses the same access token initialization as `Directions`. Once that is configured, you need to fill  `MatrixOptions` parameters to calculate the desired matrix:
+
+``` swift
+let matrix = Matrix(credentials: Credentials(accessToken: "<#your access token#>")
+let waypoints = [
+    Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.751668, longitude: -122.418408), name: "Mission Street"),
+    Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.755184, longitude: -122.422959), name: "22nd Street"),
+    Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.759695, longitude: -122.426911))
+]
+let matrixOptions = MatrixOptions(waypoints: , profileIdentifier: .automobile)
+matrix.calculate(matrixOptions) { session, result in
+    if case .success(let response) = result {
+        print("Expected route duration from '\(waypoints[0].name)' to '\(waypoints[1].name)' is \(response.travelTime(from:0, to: 1)! / 60) minutes.")
+    }
+}
+```
 
 ## Usage with other Mapbox libraries
 

--- a/Sources/MapboxDirections/AttributeOptions.swift
+++ b/Sources/MapboxDirections/AttributeOptions.swift
@@ -46,7 +46,7 @@ public struct AttributeOptions: CustomValueOptionSet, CustomStringConvertible {
     /**
      Current average speed (in meters per second) along the segment.
      
-     When this attribute is specified, the `RouteLeg.segmentSpeeds` property contains one value for each segment in the leg’s full geometry. This attribute is supported only by Directions and Map Matching requests
+     When this attribute is specified, the `RouteLeg.segmentSpeeds` property contains one value for each segment in the leg’s full geometry. This attribute is supported only by Directions and Map Matching requests.
      */
     public static let speed = AttributeOptions(rawValue: 1 << 3)
     
@@ -62,7 +62,7 @@ public struct AttributeOptions: CustomValueOptionSet, CustomStringConvertible {
     /**
      The maximum speed limit along the segment.
      
-     When this attribute is specified, the `RouteLeg.segmentMaximumSpeedLimits` property contains one value for each segment in the leg’s full geometry. This attribute is supported only by Directions and Map Matching requests
+     When this attribute is specified, the `RouteLeg.segmentMaximumSpeedLimits` property contains one value for each segment in the leg’s full geometry. This attribute is supported only by Directions and Map Matching requests.
      */
     public static let maximumSpeedLimit = AttributeOptions(rawValue: 1 << 5)
 

--- a/Sources/MapboxDirections/AttributeOptions.swift
+++ b/Sources/MapboxDirections/AttributeOptions.swift
@@ -23,7 +23,7 @@ public struct AttributeOptions: CustomValueOptionSet, CustomStringConvertible {
       
       When this attribute is specified, the `RouteLeg.closures` property is filled with relevant data.
       
-      This attribute requires `ProfileIdentifier.automobileAvoidingTraffic`.
+      This attribute requires `ProfileIdentifier.automobileAvoidingTraffic` and is supported only by Directions and Map Matching requests.
      */
     public static let closures = AttributeOptions(rawValue: 1)
     
@@ -31,6 +31,7 @@ public struct AttributeOptions: CustomValueOptionSet, CustomStringConvertible {
      Distance (in meters) along the segment.
      
      When this attribute is specified, the `RouteLeg.segmentDistances` property contains one value for each segment in the leg’s full geometry.
+     When used in Matrix request - will produce a distances matrix in response.
      */
     public static let distance = AttributeOptions(rawValue: 1 << 1)
     
@@ -38,13 +39,14 @@ public struct AttributeOptions: CustomValueOptionSet, CustomStringConvertible {
      Expected travel time (in seconds) along the segment.
      
      When this attribute is specified, the `RouteLeg.expectedSegmentTravelTimes` property contains one value for each segment in the leg’s full geometry.
+     When used in Matrix request - will produce a durations matrix in response.
      */
     public static let expectedTravelTime = AttributeOptions(rawValue: 1 << 2)
 
     /**
      Current average speed (in meters per second) along the segment.
      
-     When this attribute is specified, the `RouteLeg.segmentSpeeds` property contains one value for each segment in the leg’s full geometry.
+     When this attribute is specified, the `RouteLeg.segmentSpeeds` property contains one value for each segment in the leg’s full geometry. This attribute is supported only by Directions and Map Matching requests
      */
     public static let speed = AttributeOptions(rawValue: 1 << 3)
     
@@ -53,14 +55,14 @@ public struct AttributeOptions: CustomValueOptionSet, CustomStringConvertible {
      
      When this attribute is specified, the `RouteLeg.congestionLevels` property contains one value for each segment in the leg’s full geometry.
      
-     This attribute requires `ProfileIdentifier.automobileAvoidingTraffic`. Any other profile identifier produces `CongestionLevel.unknown` for each segment along the route.
+     This attribute requires `ProfileIdentifier.automobileAvoidingTraffic` and is supported only by Directions and Map Matching requests. Any other profile identifier produces `CongestionLevel.unknown` for each segment along the route.
      */
     public static let congestionLevel = AttributeOptions(rawValue: 1 << 4)
     
     /**
      The maximum speed limit along the segment.
      
-     When this attribute is specified, the `RouteLeg.segmentMaximumSpeedLimits` property contains one value for each segment in the leg’s full geometry.
+     When this attribute is specified, the `RouteLeg.segmentMaximumSpeedLimits` property contains one value for each segment in the leg’s full geometry. This attribute is supported only by Directions and Map Matching requests
      */
     public static let maximumSpeedLimit = AttributeOptions(rawValue: 1 << 5)
 
@@ -69,7 +71,7 @@ public struct AttributeOptions: CustomValueOptionSet, CustomStringConvertible {
 
      When this attribute is specified, the `RouteLeg.numericCongestionLevels` property contains one value for each segment in the leg’s full geometry.
 
-     This attribute requires `ProfileIdentifier.automobileAvoidingTraffic`. Any other profile identifier produces `nil` for each segment along the route.
+     This attribute requires `ProfileIdentifier.automobileAvoidingTraffic` and is supported only by Directions and Map Matching requests. Any other profile identifier produces `nil` for each segment along the route.
      */
     public static let numericCongestionLevel = AttributeOptions(rawValue: 1 << 6)
     

--- a/Sources/MapboxDirections/Extensions/URL+Request.swift
+++ b/Sources/MapboxDirections/Extensions/URL+Request.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 extension URL {
     init(path: String, host: URL) {

--- a/Sources/MapboxDirections/Extensions/URL+Request.swift
+++ b/Sources/MapboxDirections/Extensions/URL+Request.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+extension URL {
+    init(path: String, host: URL) {
+        guard let url = URL(string: path, relativeTo: host) else {
+            assertionFailure("Cannot form valid URL from '\(path)' relative to '\(host)'")
+            self = host
+            return
+        }
+        self = url
+    }
+}
+
+extension URLRequest {
+    mutating func setupUserAgentString() {
+        setValue(userAgent, forHTTPHeaderField: "User-Agent")
+    }
+}
+
+/// The user agent string for any HTTP requests performed directly within this library.
+let userAgent: String = {
+    var components: [String] = []
+    
+    if let appName = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        components.append("\(appName)/\(version)")
+    }
+    
+    let libraryBundle: Bundle? = Bundle(for: Directions.self)
+    
+    if let libraryName = libraryBundle?.infoDictionary?["CFBundleName"] as? String, let version = libraryBundle?.infoDictionary?["CFBundleShortVersionString"] as? String {
+        components.append("\(libraryName)/\(version)")
+    }
+    
+    // `ProcessInfo().operatingSystemVersionString` can replace this when swift-corelibs-foundaton is next released:
+    // https://github.com/apple/swift-corelibs-foundation/blob/main/Sources/Foundation/ProcessInfo.swift#L104-L202
+    let system: String
+    #if os(macOS)
+        system = "macOS"
+    #elseif os(iOS)
+        system = "iOS"
+    #elseif os(watchOS)
+        system = "watchOS"
+    #elseif os(tvOS)
+        system = "tvOS"
+    #elseif os(Linux)
+        system = "Linux"
+    #else
+        system = "unknown"
+    #endif
+    let systemVersion = ProcessInfo.processInfo.operatingSystemVersion
+    components.append("\(system)/\(systemVersion.majorVersion).\(systemVersion.minorVersion).\(systemVersion.patchVersion)")
+    
+    let chip: String
+    #if arch(x86_64)
+        chip = "x86_64"
+    #elseif arch(arm)
+        chip = "arm"
+    #elseif arch(arm64)
+        chip = "arm64"
+    #elseif arch(i386)
+        chip = "i386"
+    #else
+        // Maybe fall back on `uname(2).machine`?
+        chip = "unrecognized"
+    #endif
+    
+    var simulator: String? = nil
+    #if targetEnvironment(simulator)
+    simulator = "Simulator"
+    #endif
+    
+    let otherComponents = [
+        chip,
+        simulator
+    ].compactMap({ $0 })
+    
+    components.append("(\(otherComponents.joined(separator: "; ")))")
+    
+    return components.joined(separator: " ")
+}()

--- a/Sources/MapboxDirections/Isochrones.swift
+++ b/Sources/MapboxDirections/Isochrones.swift
@@ -149,7 +149,7 @@ open class Isochrones {
         var params = options.urlQueryItems
         params.append(URLQueryItem(name: "access_token", value: credentials.accessToken))
 
-        let unparameterizedURL = URL(string: options.path, relativeTo: credentials.host)!
+        let unparameterizedURL = URL(path: options.path, host: credentials.host)
         var components = URLComponents(url: unparameterizedURL, resolvingAgainstBaseURL: true)!
         components.queryItems = params
         return components.url!
@@ -164,7 +164,7 @@ open class Isochrones {
     open func urlRequest(forCalculating options: IsochroneOptions) -> URLRequest {
         let getURL = self.url(forCalculating: options)
         var request = URLRequest(url: getURL)
-        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        request.setupUserAgentString()
         return request
     }
 }

--- a/Sources/MapboxDirections/Matrix.swift
+++ b/Sources/MapboxDirections/Matrix.swift
@@ -1,0 +1,171 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+
+/**
+ Computes distances and durations between origin-destination pairs, and returns the resulting distances in meters and durations in seconds.
+ */
+open class Matrix {
+    /**
+     A tuple type representing the matrix session that was generated from the request.
+     
+     - parameter options: A `MatrixOptions ` object representing the request parameter options.
+     
+     - parameter credentials: A object containing the credentials used to make the request.
+     */
+    public typealias Session = (options: MatrixOptions, credentials: Credentials)
+    
+    /**
+     A closure (block) to be called when a matrix request is complete.
+     
+     - parameter session: A `Matrix.Session` object containing session information
+     
+     - parameter result: A `Result` enum that represents the (RETURN TYPE) if the request returned successfully, or the error if it did not.
+     */
+    public typealias MatrixCompletionHandler = (_ session: Session, _ result: Result<MatrixResponse, MatrixError>) -> Void
+    
+    // MARK: Creating an Matrix Object
+    public let credentials: Credentials
+    private let urlSession: URLSession
+    private let processingQueue: DispatchQueue
+    
+    /**
+     The shared matrix object.
+     
+     To use this object, a Mapbox [access token](https://docs.mapbox.com/help/glossary/access-token/) should be specified in the `MBXAccessToken` key in the main application bundle’s Info.plist.
+     */
+    public static let shared = Matrix()
+    
+    /**
+     Creates a new instance of Matrix object.
+     - Parameters:
+       - credentials: Credentials that will be used to make API requests to Mapbox Matrix API.
+       - urlSession: URLSession that will be used to submit API requests to Mapbox Matrix API.
+       - processingQueue: A DispatchQueue that will be used for CPU intensive work.
+     */
+    public init(credentials: Credentials = .init(),
+                urlSession: URLSession = .shared,
+                processingQueue: DispatchQueue = .global(qos: .userInitiated)) {
+        self.credentials = credentials
+        self.urlSession = urlSession
+        self.processingQueue = processingQueue
+    }
+    
+    // MARK: Getting Matrix
+    /**
+     Begins asynchronously calculating matrices using the given options and delivers the results to a closure.
+     
+     This method retrieves the matrices asynchronously from the [Mapbox Matrix API](https://docs.mapbox.com/api/navigation/matrix/) over a network connection. If a connection error or server error occurs, details about the error are passed into the given completion handler in lieu of the contours.
+     
+     - parameter options: A `MatrixOptions` object specifying the requirements for the resulting matrices.
+     - parameter completionHandler: The closure (block) to call with the resulting matrices. This closure is executed on the application’s main thread.
+     - returns: The data task used to perform the HTTP request. If, while waiting for the completion handler to execute, you no longer want the resulting matrices, cancel this task.
+     */
+    @discardableResult open func calculate(_ options: MatrixOptions, completionHandler: @escaping MatrixCompletionHandler) -> URLSessionDataTask {
+        let session = (options: options, credentials: self.credentials)
+        let request = urlRequest(forCalculating: options)
+        let requestTask = urlSession.dataTask(with: request) { (possibleData, possibleResponse, possibleError) in
+            
+            if let urlError = possibleError as? URLError {
+                DispatchQueue.main.async {
+                    completionHandler(session, .failure(.network(urlError)))
+                }
+                return
+            }
+            
+            guard let response = possibleResponse, ["application/json", "text/html"].contains(response.mimeType) else {
+                DispatchQueue.main.async {
+                    completionHandler(session, .failure(.invalidResponse(possibleResponse)))
+                }
+                return
+            }
+            
+            guard let data = possibleData else {
+                DispatchQueue.main.async {
+                    completionHandler(session, .failure(.noData))
+                }
+                return
+            }
+            
+            self.processingQueue.async {
+                do {
+                    let decoder = JSONDecoder()
+                    
+                    guard let disposition = try? decoder.decode(ResponseDisposition.self, from: data) else {
+                        let apiError = MatrixError(code: nil, message: nil, response: response, underlyingError: possibleError)
+                        
+                        DispatchQueue.main.async {
+                            completionHandler(session, .failure(apiError))
+                        }
+                        return
+                    }
+                    
+                    guard (disposition.code == nil && disposition.message == nil) || disposition.code == "Ok" else {
+                        let apiError = MatrixError(code: disposition.code, message: disposition.message, response: response, underlyingError: possibleError)
+                        
+                        DispatchQueue.main.async {
+                            completionHandler(session, .failure(apiError))
+                        }
+                        return
+                    }
+                    
+                    let result = try decoder.decode(MatrixResponse.self, from: data)
+                    
+                    guard result.distances != nil || result.travelTimes != nil else {
+                        DispatchQueue.main.async {
+                            completionHandler(session, .failure(.noRoute))
+                        }
+                        return
+                    }
+                    
+                    DispatchQueue.main.async {
+                        completionHandler(session, .success(result))
+                    }
+                    
+                } catch {
+                    DispatchQueue.main.async {
+                        let bailError = MatrixError(code: nil, message: nil, response: response, underlyingError: error)
+                        completionHandler(session, .failure(bailError))
+                    }
+                }
+            }
+        }
+        requestTask.priority = 1
+        requestTask.resume()
+        
+        return requestTask
+    }
+    
+    // MARK: Request URL Preparation
+    /**
+     The GET HTTP URL used to fetch the matrices from the Matrix API.
+     
+     - parameter options: A `MatrixOptions` object specifying the requirements for the resulting contours.
+     - returns: The URL to send the request to.
+     */
+    open func url(forCalculating options: MatrixOptions) -> URL {
+        
+        var params = options.urlQueryItems
+        params.append(URLQueryItem(name: "access_token", value: credentials.accessToken))
+
+        let unparameterizedURL = URL(string: options.path, relativeTo: credentials.host)!
+        var components = URLComponents(url: unparameterizedURL, resolvingAgainstBaseURL: true)!
+        components.queryItems = params
+        return components.url!
+    }
+    
+    /**
+     The HTTP request used to fetch the matrices from the Matrix API.
+     
+     - parameter options: A `MatrixOptions` object specifying the requirements for the resulting routes.
+     - returns: A GET HTTP request to calculate the specified options.
+     */
+    open func urlRequest(forCalculating options: MatrixOptions) -> URLRequest {
+        let getURL = self.url(forCalculating: options)
+        var request = URLRequest(url: getURL)
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        return request
+    }
+}

--- a/Sources/MapboxDirections/Matrix.swift
+++ b/Sources/MapboxDirections/Matrix.swift
@@ -27,6 +27,12 @@ open class Matrix {
     public typealias MatrixCompletionHandler = (_ session: Session, _ result: Result<MatrixResponse, MatrixError>) -> Void
     
     // MARK: Creating an Matrix Object
+    
+    /**
+     The Authorization & Authentication credentials that are used for this service.
+     
+     If nothing is provided, the default behavior is to read credential values from the developer's Info.plist.
+     */
     public let credentials: Credentials
     private let urlSession: URLSession
     private let processingQueue: DispatchQueue
@@ -150,7 +156,7 @@ open class Matrix {
         var params = options.urlQueryItems
         params.append(URLQueryItem(name: "access_token", value: credentials.accessToken))
 
-        let unparameterizedURL = URL(string: options.path, relativeTo: credentials.host)!
+        let unparameterizedURL = URL(path: options.path, host: credentials.host)
         var components = URLComponents(url: unparameterizedURL, resolvingAgainstBaseURL: true)!
         components.queryItems = params
         return components.url!
@@ -165,7 +171,7 @@ open class Matrix {
     open func urlRequest(forCalculating options: MatrixOptions) -> URLRequest {
         let getURL = self.url(forCalculating: options)
         var request = URLRequest(url: getURL)
-        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        request.setupUserAgentString()
         return request
     }
 }

--- a/Sources/MapboxDirections/MatrixError.swift
+++ b/Sources/MapboxDirections/MatrixError.swift
@@ -1,0 +1,75 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/**
+ An error that occurs when computing matrices.
+ */
+public enum MatrixError: LocalizedError {
+    
+    public init(code: String?, message: String?, response: URLResponse?, underlyingError error: Error?) {
+        if let response = response as? HTTPURLResponse {
+            switch (response.statusCode, code ?? "") {
+            case (200, "NoRoute"):
+                self = .noRoute
+            case (404, "ProfileNotFound"):
+                self = .profileNotFound
+            case (422, "InvalidInput"):
+                self = .invalidInput(message: message)
+            case (429, _):
+                self = .rateLimited(rateLimitInterval: response.rateLimitInterval, rateLimit: response.rateLimit, resetTime: response.rateLimitResetTime)
+            default:
+                self = .unknown(response: response, underlying: error, code: code, message: message)
+            }
+        } else {
+            self = .unknown(response: response, underlying: error, code: code, message: message)
+        }
+    }
+    
+    /**
+     There is no network connection available to perform the network request.
+     */
+    case network(_: URLError)
+    
+    /**
+     The server returned a response that isn’t correctly formatted.
+     */
+    case invalidResponse(_: URLResponse?)
+    
+    /**
+     The server returned an empty response.
+     */
+    case noData
+    
+    /**
+     The API did not find a route for the given coordinates. Check for impossible routes or incorrectly formatted coordinates.
+     */
+    case noRoute
+    
+    /**
+     Unrecognized profile identifier.
+     
+     Make sure the `MatrixOptions.profileIdentifier` option is set to one of the predefined values, such as `MatrixProfileIdentifier.automobile`.
+     */
+    case profileNotFound
+    
+    /**
+     The API recieved input that it didn't understand.
+     
+     Make sure the number of approach elements matches the number of waypoints provided, and the number of waypoints does not exceed the maximum number per request.
+     */
+    case invalidInput(message: String?)
+    
+    /**
+     Too many requests have been made with the same access token within a certain period of time.
+     
+     Wait before retrying.
+     */
+    case rateLimited(rateLimitInterval: TimeInterval?, rateLimit: UInt?, resetTime: Date?)
+    
+    /**
+     Unknown error case. Look at associated values for more details.
+     */
+    case unknown(response: URLResponse?, underlying: Error?, code: String?, message: String?)
+}

--- a/Sources/MapboxDirections/MatrixOptions.swift
+++ b/Sources/MapboxDirections/MatrixOptions.swift
@@ -6,16 +6,22 @@ import Turf
  */
 public class MatrixOptions: Codable {
     // MARK: Creating a Matrix Options Object
+    
     /**
      Initializes a matrix options object for matrices and a given profile identifier.
      
-     - parameter waypoints: An array of `Waypoints` objects representing locations that will be in the matrix. The array should contain at least X coordinates and at most X coordinates. (Some profiles, such as `ProfileIdentifier`, [may have lower limits](https://docs.mapbox.com/api/navigation/matrix/#matrix-api-restrictions-and-limits).)
+     `sources` and `destinations` should not be empty, otherwise matrix would not make sense. Total number of waypoints may differ depending on the `profileIdentifier`. [See documentation for details](https://docs.mapbox.com/api/navigation/matrix/#matrix-api-restrictions-and-limits).
+     - parameter sources: An array of `Waypoints` objects representing sources.
+     - parameter destinations: An array of `Waypoints` objects representing destinations.
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes.
      */
-    public init(waypoints: [Waypoint], profileIdentifier: ProfileIdentifier) {
-        self.waypoints = waypoints
+    public init(sources: [Waypoint], destinations: [Waypoint], profileIdentifier: ProfileIdentifier) {
         self.profileIdentifier = profileIdentifier
+        self.waypointsData = .init(sources: sources,
+                                   destinations: destinations)
     }
+    
+    private let waypointsData: WaypointsData
     
     /**
      A string specifying the primary mode of transportation for the contours.
@@ -25,7 +31,9 @@ public class MatrixOptions: Codable {
     /**
      An array of `Waypoints` objects representing locations that will be in the matrix.
      */
-    public var waypoints: [Waypoint]
+    public var waypoints: [Waypoint] {
+        return waypointsData.waypoints
+    }
     
     /**
      Attribute options for the matrix.
@@ -35,22 +43,35 @@ public class MatrixOptions: Codable {
     public var attributeOptions: AttributeOptions = []
     
     /**
-     The coordinates at a given index in the `waypoints` array that should be used as destinations.
+     The `waypoints` array that should be used as destinations.
      
-     By default, all waypoints in the `waypoints` array are used as destinations.
+     Must not be empty.
      */
-    public var destinations: [Int]?
+    public var destinations: [Waypoint] {
+        get {
+            waypointsData.destinations
+        }
+        set {
+            waypointsData.destinations = newValue
+        }
+    }
     
     /**
-     The coordinates at a given index in the `waypoints` array that should be used as sources.
+     The `waypoints` array that should be used as sources.
      
-     By default, all waypoints in the `waypoints` array are used as sources.
+     Must not be empty.
      */
-    public var sources: [Int]?
+    public var sources: [Waypoint] {
+        get {
+            waypointsData.sources
+        }
+        set {
+            waypointsData.sources = newValue
+        }
+    }
     
     
     private enum CodingKeys: String, CodingKey {
-        case waypoints
         case profileIdentifier = "profile"
         case attributeOptions = "annotations"
         case destinations
@@ -59,7 +80,6 @@ public class MatrixOptions: Codable {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(waypoints, forKey: .waypoints)
         try container.encode(profileIdentifier, forKey: .profileIdentifier)
         try container.encode(attributeOptions.queryDescription, forKey: .attributeOptions)
         try container.encodeIfPresent(destinations, forKey: .destinations)
@@ -68,13 +88,14 @@ public class MatrixOptions: Codable {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        waypoints = try container.decode([Waypoint].self, forKey: .waypoints)
         profileIdentifier = try container.decode(ProfileIdentifier.self, forKey: .profileIdentifier)
         if let annotations = try container.decodeIfPresent(String.self, forKey: .attributeOptions) {
             attributeOptions = Set<AttributeOption>(from: annotations)
         }
-        destinations = try container.decodeIfPresent([Int].self, forKey: .destinations)
-        sources = try container.decodeIfPresent([Int].self, forKey: .sources)
+        let destinations = try container.decodeIfPresent([Waypoint].self, forKey: .destinations) ?? []
+        let sources = try container.decodeIfPresent([Waypoint].self, forKey: .sources) ?? []
+        self.waypointsData = .init(sources: sources,
+                                   destinations: destinations)
     }
     
     // MARK: Getting the Request URL
@@ -121,15 +142,16 @@ public class MatrixOptions: Codable {
             queryItems.append(URLQueryItem(name: "approaches", value: approaches.joined(separator: ";")))
         }
         
-        if let destinations = self.destinations {
-            let destinationStrings = destinations.map { String($0)}
-            queryItems.append(URLQueryItem(name: "destinations", value: destinationStrings.joined(separator: ";")))
+        if waypoints.count != waypointsData.destinationsIndices.count {
+            let destinationString = waypointsData.destinationsIndices.map { String($0) }.joined(separator: ";")
+            queryItems.append(URLQueryItem(name: "destinations", value: destinationString))
         }
         
-        if let sources = self.sources {
-            let sourceStrings = sources.map { String($0)}
-            queryItems.append(URLQueryItem(name: "sources", value: sourceStrings.joined(separator: ";")))
+        if waypoints.count != waypointsData.sourcesIndices.count {
+            let sourceString = waypointsData.sourcesIndices.map { String($0) }.joined(separator: ";")
+            queryItems.append(URLQueryItem(name: "sources", value: sourceString))
         }
+        
         return queryItems
     }
 }
@@ -191,10 +213,59 @@ extension MatrixOptions.AttributeOptions {
 
 extension MatrixOptions: Equatable {
     public static func == (lhs: MatrixOptions, rhs: MatrixOptions) -> Bool {
-        return lhs.waypoints == rhs.waypoints &&
-            lhs.profileIdentifier == rhs.profileIdentifier &&
+        return lhs.profileIdentifier == rhs.profileIdentifier &&
             lhs.attributeOptions == rhs.attributeOptions &&
             lhs.sources == rhs.sources &&
             lhs.destinations == rhs.destinations
+    }
+}
+
+extension MatrixOptions {
+    fileprivate class WaypointsData {
+        
+        private(set) var waypoints: [Waypoint] = []
+        var sources: [Waypoint] {
+            didSet {
+                updateWaypoints()
+            }
+        }
+        var destinations: [Waypoint] {
+            didSet {
+                updateWaypoints()
+            }
+        }
+        private(set) var sourcesIndices: IndexSet = []
+        private(set) var destinationsIndices: IndexSet = []
+        
+        private func updateWaypoints() {
+            sourcesIndices = []
+            destinationsIndices = []
+            
+            var destinations = self.destinations
+            for source in sources.enumerated() {
+                for destination in destinations.enumerated() {
+                    if source.element == destination.element {
+                        destinations.remove(at: destination.offset)
+                        destinationsIndices.insert(source.offset)
+                        break
+                    }
+                }
+            }
+            
+            destinationsIndices.insert(integersIn: sources.endIndex..<(sources.endIndex + destinations.count))
+            
+            var sum = sources
+            sum.append(contentsOf: destinations)
+            waypoints = sum
+            
+            sourcesIndices = IndexSet(integersIn: sources.indices)
+        }
+        
+        init(sources: [Waypoint], destinations: [Waypoint]) {
+            self.sources = sources
+            self.destinations = destinations
+            
+            updateWaypoints()
+        }
     }
 }

--- a/Sources/MapboxDirections/MatrixOptions.swift
+++ b/Sources/MapboxDirections/MatrixOptions.swift
@@ -1,0 +1,200 @@
+import Foundation
+import Turf
+
+/**
+ Options for calculating matrices from the Mapbox Matrix service.
+ */
+public class MatrixOptions: Codable {
+    // MARK: Creating a Matrix Options Object
+    /**
+     Initializes a matrix options object for matrices and a given profile identifier.
+     
+     - parameter waypoints: An array of `Waypoints` objects representing locations that will be in the matrix. The array should contain at least X coordinates and at most X coordinates. (Some profiles, such as `ProfileIdentifier`, [may have lower limits](https://docs.mapbox.com/api/navigation/matrix/#matrix-api-restrictions-and-limits).)
+     - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes.
+     */
+    public init(waypoints: [Waypoint], profileIdentifier: ProfileIdentifier) {
+        self.waypoints = waypoints
+        self.profileIdentifier = profileIdentifier
+    }
+    
+    /**
+     A string specifying the primary mode of transportation for the contours.
+    */
+    public var profileIdentifier: ProfileIdentifier
+    
+    /**
+     An array of `Waypoints` objects representing locations that will be in the matrix.
+     */
+    public var waypoints: [Waypoint]
+    
+    /**
+     Attribute options for the matrix.
+
+     Empty `attributeOptions` will result in default values assumed.
+     */
+    public var attributeOptions: AttributeOptions = []
+    
+    /**
+     The coordinates at a given index in the `waypoints` array that should be used as destinations.
+     
+     By default, all waypoints in the `waypoints` array are used as destinations.
+     */
+    public var destinations: [Int]?
+    
+    /**
+     The coordinates at a given index in the `waypoints` array that should be used as sources.
+     
+     By default, all waypoints in the `waypoints` array are used as sources.
+     */
+    public var sources: [Int]?
+    
+    
+    private enum CodingKeys: String, CodingKey {
+        case waypoints
+        case profileIdentifier = "profile"
+        case attributeOptions = "annotations"
+        case destinations
+        case sources
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(waypoints, forKey: .waypoints)
+        try container.encode(profileIdentifier, forKey: .profileIdentifier)
+        try container.encode(attributeOptions.queryDescription, forKey: .attributeOptions)
+        try container.encodeIfPresent(destinations, forKey: .destinations)
+        try container.encodeIfPresent(sources, forKey: .sources)
+    }
+    
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        waypoints = try container.decode([Waypoint].self, forKey: .waypoints)
+        profileIdentifier = try container.decode(ProfileIdentifier.self, forKey: .profileIdentifier)
+        if let annotations = try container.decodeIfPresent(String.self, forKey: .attributeOptions) {
+            attributeOptions = Set<AttributeOption>(from: annotations)
+        }
+        destinations = try container.decodeIfPresent([Int].self, forKey: .destinations)
+        sources = try container.decodeIfPresent([Int].self, forKey: .sources)
+    }
+    
+    // MARK: Getting the Request URL
+    
+    internal var coordinates: String? {
+        waypoints.map {
+            $0.coordinate.requestDescription
+        }.joined(separator: ";")
+    }
+    
+    /**
+        An array of URL query items to include in an HTTP request.
+    */
+   var abridgedPath: String {
+       return "directions-matrix/v1/\(profileIdentifier.rawValue)"
+   }
+
+   /**
+    The path of the request URL, not including the hostname or any parameters.
+    */
+   var path: String {
+    guard let coordinates = coordinates,
+          !coordinates.isEmpty else {
+        assertionFailure("No query")
+        return ""
+    }
+    return "\(abridgedPath)/\(coordinates)"
+   }
+    
+    /**
+     An array of URL query items (parameters) to include in an HTTP request.
+     */
+    public var urlQueryItems: [URLQueryItem] {
+        var queryItems: [URLQueryItem] = []
+        
+        let annotations = self.attributeOptions
+        if !annotations.isEmpty && annotations.isSubset(of: [.distance, .travelTime]) {
+            queryItems.append((URLQueryItem(name: "annotations", value: annotations.queryDescription)))
+        }
+        
+        let mustArriveOnDrivingSide = !waypoints.filter { !$0.allowsArrivingOnOppositeSide }.isEmpty
+        if mustArriveOnDrivingSide {
+            let approaches = waypoints.map { $0.allowsArrivingOnOppositeSide ? "unrestricted" : "curb" }
+            queryItems.append(URLQueryItem(name: "approaches", value: approaches.joined(separator: ";")))
+        }
+        
+        if let destinations = self.destinations {
+            let destinationStrings = destinations.map { String($0)}
+            queryItems.append(URLQueryItem(name: "destinations", value: destinationStrings.joined(separator: ";")))
+        }
+        
+        if let sources = self.sources {
+            let sourceStrings = sources.map { String($0)}
+            queryItems.append(URLQueryItem(name: "sources", value: sourceStrings.joined(separator: ";")))
+        }
+        return queryItems
+    }
+}
+
+extension MatrixOptions {
+    
+    /**
+     Attributes are metadata information for requesting matricies.
+     
+     Options selected affect the contents of the resulting `MatrixResponse`.
+     */
+    public typealias AttributeOptions = Set<AttributeOption>
+    
+    public struct AttributeOption: Hashable, RawRepresentable {
+        public typealias RawValue = String
+        
+        /**
+         Textual representation of an option.
+         
+         Used to compose an URL request.
+         */
+        public var rawValue: RawValue
+        
+        /**
+         Creates new `AttributeOption`.
+         */
+        public init(rawValue: RawValue) {
+            self.rawValue = rawValue
+        }
+        
+        /**
+         Used to specify the resulting matrices to contain distances matrix.
+         
+         If this attribute is specified, the `MatrixResponse.distances` will contain distance values for each source - destination route.
+         */
+        public static let distance: AttributeOption = .init(rawValue: "distance")
+        
+        /**
+         Used to specify the resulting matrices to contain expected travel times matrix.
+         
+         If this attribute is specified, the `MatrixResponse.distances` will contain duration values for each source - destination route.
+         */
+        public static let travelTime: AttributeOption = .init(rawValue: "duration")
+    }
+}
+
+extension MatrixOptions.AttributeOptions {
+    var queryDescription: String {
+        return map { $0.rawValue }.joined(separator:",")
+    }
+    
+    init(from description: String) {
+        self.init()
+        description.split(separator: ",").forEach {
+            self.insert(MatrixOptions.AttributeOption(rawValue: String($0)))
+        }
+    }
+}
+
+extension MatrixOptions: Equatable {
+    public static func == (lhs: MatrixOptions, rhs: MatrixOptions) -> Bool {
+        return lhs.waypoints == rhs.waypoints &&
+            lhs.profileIdentifier == rhs.profileIdentifier &&
+            lhs.attributeOptions == rhs.attributeOptions &&
+            lhs.sources == rhs.sources &&
+            lhs.destinations == rhs.destinations
+    }
+}

--- a/Sources/MapboxDirections/MatrixResponse.swift
+++ b/Sources/MapboxDirections/MatrixResponse.swift
@@ -1,0 +1,127 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public struct MatrixResponse {
+    public typealias DistanceMatrix = [[CLLocationDistance?]]
+    public typealias DurationMatrix = [[TimeInterval?]]
+    
+    public let httpResponse: HTTPURLResponse?
+    
+    public let destinations: [Waypoint]?
+    public let sources: [Waypoint]?
+    
+    /**
+     Array of arrays that represent the distances matrix in row-major order.
+     
+     `distances[i][j]` gives the route distance from the `i`'th `source` to the `j`'th `destination`. The distance between the same coordinate is always `0`. Distance from `i` to `j` is not always the same as from `j` to `i`. If a route cannot be found, the result is `null`.
+     
+     - seealso: `distance(from:to:)`
+     */
+    public let distances: DistanceMatrix?
+    
+    /**
+     Array of arrays that represent the travel times matrix in row-major order.
+     
+     `travelTimes[i][j]` gives the travel time from the `i`'th `source` to the `j`'th `destination`. The duration between the same coordinate is always `0`. Travel time from `i` to `j` is not always the same as from `j` to `i`. If a duration cannot be found, the result is `null`.
+     
+     - seealso: `travelTime(from:to:)`
+     */
+    public let travelTimes: DurationMatrix?
+    
+    /**
+     Returns route distance between specified source and destination.
+     
+     - parameter sourceIndex: Index of a waypoint in `sources` array.
+     - parameter destinationIndex: Index of a waypoint in `destinations` array.
+     - returns Calculated route distance between the points or `null` if it is not available.
+     */
+    public func distance(from sourceIndex: Int, to destinationIndex: Int) -> CLLocationDistance? {
+        guard sources?.indices.contains(sourceIndex) ?? false &&
+                destinations?.indices.contains(destinationIndex) ?? false else {
+            return nil
+        }
+        return distances?[sourceIndex][destinationIndex]
+    }
+    
+    /**
+     Returns expected travel time between specified source and destination.
+     
+     - parameter sourceIndex: Index of a waypoint in `sources` array.
+     - parameter destinationIndex: Index of a waypoint in `destinations` array.
+     - returns Calculated expected travel time between the points or `null` if it is not available.
+     */
+    public func travelTime(from sourceIndex: Int, to destinationIndex: Int) -> TimeInterval? {
+        guard sources?.indices.contains(sourceIndex) ?? false &&
+                destinations?.indices.contains(destinationIndex) ?? false else {
+            return nil
+        }
+        return travelTimes?[sourceIndex][destinationIndex]
+    }
+}
+
+extension MatrixResponse: Codable {
+    enum CodingKeys: String, CodingKey {
+        case distances
+        case durations
+        case destinations
+        case sources
+    }
+    
+    public init(httpResponse: HTTPURLResponse?,
+                distances: DistanceMatrix?,
+                travelTimes: DurationMatrix?,
+                destinations: [Waypoint]?,
+                sources: [Waypoint]?) {
+        self.httpResponse = httpResponse
+        self.destinations = destinations
+        self.sources = sources
+        self.distances = distances
+        self.travelTimes = travelTimes
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        var distancesMatrix: DistanceMatrix = []
+        var durationsMatrix: DurationMatrix = []
+        
+        self.httpResponse = decoder.userInfo[.httpResponse] as? HTTPURLResponse
+        self.destinations = try container.decode([Waypoint].self, forKey: .destinations)
+        self.sources = try container.decode([Waypoint].self, forKey: .sources)
+        
+        if let decodedDistances = try container.decodeIfPresent([[Double?]].self, forKey: .distances) {
+            decodedDistances.forEach { distanceArray in
+                var distances: Array<CLLocationDistance?> = []
+                distanceArray.forEach { distance in
+                    distances.append(distance)
+                }
+                distancesMatrix.append(distances)
+            }
+            self.distances = distancesMatrix
+        } else {
+            self.distances = nil
+        }
+        
+        if let decodedDurations = try container.decodeIfPresent([[Double?]].self, forKey: .durations) {
+            decodedDurations.forEach { durationArray in
+                var durations: Array<TimeInterval?> = []
+                durationArray.forEach { duration in
+                    durations.append(duration)
+                }
+                durationsMatrix.append(durations)
+            }
+            self.travelTimes = durationsMatrix
+        } else {
+            self.travelTimes = nil
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(destinations, forKey: .destinations)
+        try container.encode(sources, forKey: .sources)
+        try container.encodeIfPresent(distances, forKey: .distances)
+        try container.encodeIfPresent(travelTimes, forKey: .durations)
+    }
+}

--- a/Sources/MapboxDirections/MatrixResponse.swift
+++ b/Sources/MapboxDirections/MatrixResponse.swift
@@ -2,9 +2,10 @@ import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
+import Turf
 
 public struct MatrixResponse {
-    public typealias DistanceMatrix = [[CLLocationDistance?]]
+    public typealias DistanceMatrix = [[LocationDistance?]]
     public typealias DurationMatrix = [[TimeInterval?]]
     
     public let httpResponse: HTTPURLResponse?
@@ -37,7 +38,7 @@ public struct MatrixResponse {
      - parameter destinationIndex: Index of a waypoint in `destinations` array.
      - returns Calculated route distance between the points or `null` if it is not available.
      */
-    public func distance(from sourceIndex: Int, to destinationIndex: Int) -> CLLocationDistance? {
+    public func distance(from sourceIndex: Int, to destinationIndex: Int) -> LocationDistance? {
         guard sources?.indices.contains(sourceIndex) ?? false &&
                 destinations?.indices.contains(destinationIndex) ?? false else {
             return nil
@@ -92,7 +93,7 @@ extension MatrixResponse: Codable {
         
         if let decodedDistances = try container.decodeIfPresent([[Double?]].self, forKey: .distances) {
             decodedDistances.forEach { distanceArray in
-                var distances: Array<CLLocationDistance?> = []
+                var distances: Array<LocationDistance?> = []
                 distanceArray.forEach { distance in
                     distances.append(distance)
                 }

--- a/Tests/MapboxDirectionsTests/Fixtures/matrix.json
+++ b/Tests/MapboxDirectionsTests/Fixtures/matrix.json
@@ -1,0 +1,47 @@
+{
+    "code": "Ok",
+    "durations": [
+        [ 0,      null, 1169.5 ],
+        [ 573,    0,    597 ],
+        [ null,   null, null ]
+    ],
+    "distances": [
+        [ 0,      null, 11695 ],
+        [ 5730,    0,    5970 ],
+        [ null,   null, null ]
+    ],
+    "destinations": [
+        {
+            "name": "Mission Street",
+            "location": [ -122.418408, 37.751668 ],
+            "distance": 5
+        },
+        {
+            "name": "22nd Street",
+            "location": [ -122.422959, 37.755184 ],
+            "distance": 8
+        },
+        {
+            "name": "",
+            "location": [ -122.426911, 37.759695 ],
+            "distance": 10
+        }
+    ],
+    "sources": [
+        {
+            "name": "Mission Street",
+            "location": [ -122.418408, 37.751668 ],
+            "distance": 5
+        },
+        {
+            "name": "22nd Street",
+            "location": [ -122.422959, 37.755184 ],
+            "distance": 8
+        },
+        {
+            "name": "",
+            "location": [ -122.426911, 37.759695 ],
+            "distance": 10
+        }
+    ]
+}

--- a/Tests/MapboxDirectionsTests/MatrixTests.swift
+++ b/Tests/MapboxDirectionsTests/MatrixTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+#if !os(Linux)
+import OHHTTPStubs
+#if SWIFT_PACKAGE
+import OHHTTPStubsSwift
+#endif
+#endif
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Turf
+@testable import MapboxDirections
+
+let MatrixBogusCredentials = Credentials(accessToken: BogusToken)
+
+#if !os(Linux)
+class MatrixTests: XCTestCase {
+    override func tearDown() {
+        #if !os(Linux)
+        HTTPStubs.removeAllStubs()
+        #endif
+        super.tearDown()
+    }
+    
+    func testConfiguration() {
+        let matrices = Matrix(credentials: MatrixBogusCredentials)
+        XCTAssertEqual(matrices.credentials, MatrixBogusCredentials)
+    }
+    
+    func testRequest() {
+        let waypoints = [
+            Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.751668, longitude: -122.418408), name: "Mission Street"),
+            Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.755184, longitude: -122.422959), name: "22nd Street"),
+            Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.759695, longitude: -122.426911))
+        ]
+        
+        let options = MatrixOptions(waypoints: waypoints, profileIdentifier: .automobile)
+        options.destinations = [0, 1, 2]
+        options.sources = [0, 1, 2]
+        options.attributeOptions = [.distance, .travelTime]
+
+        let matrices = Matrix(credentials: MatrixBogusCredentials)
+        let url = matrices.url(forCalculating: options)
+        let request = matrices.urlRequest(forCalculating: options)
+
+        guard let components = URLComponents(string: url.absoluteString),
+              let queryItems = components.queryItems else { XCTFail("Invalid url"); return }
+
+        XCTAssertEqual(queryItems.count, 4)
+        XCTAssertTrue(components.path.contains(waypoints.compactMap { $0.coordinate.requestDescription
+        }.joined(separator: ";")))
+        XCTAssertTrue(queryItems.contains(where: { $0.name == "access_token" && $0.value == BogusToken }))
+        XCTAssertTrue(queryItems.contains(where: {
+            let annotations = Set($0.value?.split(separator: ",").map { String($0) } ?? [])
+            return $0.name == "annotations" &&
+                   annotations == Set(["distance", "duration"])
+        }))
+        XCTAssertTrue(queryItems.contains(where: { $0.name == "destinations" && $0.value == "0;1;2"}))
+        XCTAssertTrue(queryItems.contains(where: { $0.name == "sources" && $0.value == "0;1;2"}))
+        
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.url, url)
+    }
+    
+
+    func testUnknownBadResponse() {
+        let message = "Lorem ipsum."
+        HTTPStubs.stubRequests(passingTest: { (request) -> Bool in
+            return request.url!.absoluteString.contains("https://api.mapbox.com/directions-matrix")
+        }) { (_) -> HTTPStubsResponse in
+            return HTTPStubsResponse(data: message.data(using: .utf8)!, statusCode: 420, headers: ["Content-Type" : "text/plain"])
+        }
+        let expectation = self.expectation(description: "Async callback")
+        let one = CLLocation(latitude: 0.0, longitude: 0.0)
+        let two = CLLocation(latitude: 2.0, longitude: 2.0)
+        let waypoints = [Waypoint(location: one), Waypoint(location: two)]
+        
+        let matrix = Matrix(credentials: MatrixBogusCredentials)
+        let options = MatrixOptions(waypoints: waypoints, profileIdentifier: .automobile)
+        matrix.calculate(options, completionHandler: { (session, result) in
+            defer { expectation.fulfill() }
+
+            guard case let .failure(error) = result else {
+                XCTFail("Expecting an error, none returned. \(result)")
+                return
+            }
+
+            guard case .invalidResponse(_) = error else {
+                XCTFail("Wrong error type returned.")
+                return
+            }
+        })
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testDownNetwork() {
+        let notConnected = NSError(domain: NSURLErrorDomain, code: URLError.notConnectedToInternet.rawValue) as! URLError
+        
+        HTTPStubs.stubRequests(passingTest: { (request) -> Bool in
+            return request.url!.absoluteString.contains("https://api.mapbox.com/directions-matrix")
+        }) { (_) -> HTTPStubsResponse in
+            return HTTPStubsResponse(error: notConnected)
+        }
+
+        let expectation = self.expectation(description: "Async callback")
+        let one = CLLocation(latitude: 0.0, longitude: 0.0)
+        let two = CLLocation(latitude: 2.0, longitude: 2.0)
+        let waypoints = [Waypoint(location: one), Waypoint(location: two)]
+        
+        let matrix = Matrix(credentials: MatrixBogusCredentials)
+        let options = MatrixOptions(waypoints: waypoints, profileIdentifier: .automobile)
+        
+        matrix.calculate(options, completionHandler: { (session, result) in
+            defer { expectation.fulfill() }
+
+            guard case let .failure(error) = result else {
+                XCTFail("Error expected, none returned. \(result)")
+                return
+            }
+
+            guard case let .network(err) = error else {
+                XCTFail("Wrong error type returned. \(error)")
+                return
+            }
+
+            // Comparing just the code and domain to avoid comparing unessential `UserInfo` that might be added.
+            XCTAssertEqual(type(of: err).errorDomain, type(of: notConnected).errorDomain)
+            XCTAssertEqual(err.code, notConnected.code)
+        })
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testRateLimitErrorParsing() {
+        let url = URL(string: "https://api.mapbox.com")!
+        let headerFields = ["X-Rate-Limit-Interval" : "60", "X-Rate-Limit-Limit" : "600", "X-Rate-Limit-Reset" : "1479460584"]
+        let response = HTTPURLResponse(url: url, statusCode: 429, httpVersion: nil, headerFields: headerFields)
+
+        let resultError = MatrixError(code: "429", message: "Hit rate limit", response: response, underlyingError: nil)
+        if case let .rateLimited(rateLimitInterval, rateLimit, resetTime) = resultError {
+            XCTAssertEqual(rateLimitInterval, 60.0)
+            XCTAssertEqual(rateLimit, 600)
+            XCTAssertEqual(resetTime, Date(timeIntervalSince1970: 1479460584))
+        } else {
+            XCTFail("Code 429 should be interpreted as a rate limiting error.")
+        }
+    }
+    
+    func testResponseParsing() {
+        let waypoints = [
+            Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.751668, longitude: -122.418408), name: "Mission Street"),
+            Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.755184, longitude: -122.422959), name: "22nd Street"),
+            Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.759695, longitude: -122.426911))
+        ]
+        
+        let options = MatrixOptions(waypoints: waypoints, profileIdentifier: .automobile)
+        options.destinations = [0, 1, 2]
+        options.sources = [0, 1, 2]
+        options.attributeOptions = [.distance, .travelTime]
+
+        let matrix = Matrix(credentials: MatrixBogusCredentials)
+        let expectation = expectation(description: "Handler should be called.")
+        
+        HTTPStubs.stubRequests(passingTest: { (request) -> Bool in
+            return request.url!.absoluteString.contains("https://api.mapbox.com/directions-matrix")
+        }) { (_) -> HTTPStubsResponse in
+            let response = Fixture.stringFromFileNamed(name: "matrix")
+            return HTTPStubsResponse(data: response.data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+        
+        matrix.calculate(options, completionHandler: { (session, result) in
+            defer { expectation.fulfill() }
+
+            guard case let .success(response) = result else {
+                XCTFail("Unexpected error. \(result)")
+                return
+            }
+
+            XCTAssertEqual(response.destinations, options.waypoints)
+            XCTAssertEqual(response.sources, options.waypoints)
+            XCTAssertNil(response.distance(from: 0, to: 1))
+            XCTAssertNil(response.travelTime(from: 0, to: 1))
+            XCTAssertEqual(response.travelTime(from: 1, to: 2), 597.0)
+            XCTAssertEqual(response.distance(from: 1, to: 2), 5970.0)
+            XCTAssertNotNil(response.distances?[2])
+            XCTAssertEqual(response.distances?.count, 3)
+            XCTAssertNotNil(response.travelTimes?[2])
+            XCTAssertEqual(response.travelTimes?.count, 3)
+        })
+        wait(for: [expectation], timeout: 2.0)
+    }
+}
+#endif

--- a/Tests/MapboxDirectionsTests/MatrixTests.swift
+++ b/Tests/MapboxDirectionsTests/MatrixTests.swift
@@ -37,7 +37,7 @@ class MatrixTests: XCTestCase {
         let options = MatrixOptions(sources: waypoints,
                                     destinations: waypoints,
                                     profileIdentifier: .automobile)
-        options.attributeOptions = [.distance, .travelTime]
+        options.attributeOptions = [.distance, .expectedTravelTime]
 
         let matrices = Matrix(credentials: MatrixBogusCredentials)
         let url = matrices.url(forCalculating: options)
@@ -88,7 +88,6 @@ class MatrixTests: XCTestCase {
         
         XCTAssertTrue(queryItems.contains(where: { $0.name == "approaches" && $0.value == "curb;unrestricted;unrestricted"}))
     }
-    
 
     func testUnknownBadResponse() {
         let message = "Lorem ipsum."
@@ -186,7 +185,7 @@ class MatrixTests: XCTestCase {
         let options = MatrixOptions(sources: waypoints,
                                     destinations: waypoints,
                                     profileIdentifier: .automobile)
-        options.attributeOptions = [.distance, .travelTime]
+        options.attributeOptions = [.distance, .expectedTravelTime]
 
         let matrix = Matrix(credentials: MatrixBogusCredentials)
         let expectation = expectation(description: "Handler should be called.")


### PR DESCRIPTION
Fixes #419.

This PR adds a `Matrix` object to access the Matrix API. Integration is similar to `Directions` and `Isochrones`.
Needs to be rebased on top of main.