### PR TITLE
Update Turf 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## v2.1.0
 
+### Packaging
+
+* MapboxDirections now requires [Turf v2.1.0 (up to 3.0.0, not including)](https://github.com/mapbox/turf-swift/releases/tag/v2.1.0). ([#628](https://github.com/mapbox/mapbox-directions-swift/pull/628))
+
+### Other changes
+
 * Added the `Waypoint.snappedDistance` property to get the straight-line distance from the waypoint to the location it was snapped to in the `RouteResponse`. ([#616](https://github.com/mapbox/mapbox-directions-swift/pull/616))
 * Added the `RouteOptions.initialManeuverAvoidanceRadius` property to avoid a sudden maneuver when calculating a route while the user is in motion. ([#609](https://github.com/mapbox/mapbox-directions-swift/pull/609))
 * Added the `RoadClasses.unpaved` option for avoiding unpaved roads. ([#620](https://github.com/mapbox/mapbox-directions-swift/pull/620))

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "raphaelmor/Polyline" ~> 5.0
-github "mapbox/turf-swift" ~> 2.0
+github "mapbox/turf-swift" ~> 2.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "9.1.0"
 github "mapbox/mapbox-events-ios" "v0.10.13"
-github "mapbox/turf-swift" "v2.0.0"
+github "mapbox/turf-swift" "v2.1.0"
 github "raphaelmor/Polyline" "v5.0.2"

--- a/MapboxDirections.podspec
+++ b/MapboxDirections.podspec
@@ -46,6 +46,6 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
 
   s.dependency "Polyline", "~> 5.0"
-  s.dependency "Turf", "~> 2.0"
+  s.dependency "Turf", "~> 2.1"
 
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "dccd79aee4c21298d1beb81cc0e86eccbe911ae0",
-          "version": "2.0.0"
+          "revision": "132aaf7f90fb3e334acd685ae7040a2b70b80d26",
+          "version": "2.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/raphaelmor/Polyline.git", from: "5.0.2"),
-        .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.0.0"),
+        .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.1.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs", from: "9.1.0")
     ],


### PR DESCRIPTION
Updates minimal version of Turf to 2.1.0 as it is required by the upcoming version of Navigation SDK.