### PR TITLE
Rely on Turf to encode and decode GeoJSON LineStrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.2.0
 
 * Added the `RouteResponse.roadClassViolations` property, which indicates any requested `RouteOptions.roadClassesToAvoid` values that could not be satisfied when calculating the routes. You can use convenience `RouteResponse.exclusionViolations(routeIndex:legIndex:stepIndex:intersectionIndex:)` method to search for a specific item. ([#627](https://github.com/mapbox/mapbox-directions-swift/pull/627))
+* Fixed an issue where `PolyLineString` encoded an invalid GeoJSON LineString. ([#638](https://github.com/mapbox/mapbox-directions-swift/pull/638))
 
 ## v2.1.0
 

--- a/Tests/MapboxDirectionsTests/GeoJSONTests.swift
+++ b/Tests/MapboxDirectionsTests/GeoJSONTests.swift
@@ -34,4 +34,34 @@ class GeoJSONTests: XCTestCase {
         XCTAssertEqual(lineString?.coordinates.first, lineString?.coordinates.last)
         XCTAssertEqual(lineString?.polylineEncodedString(precision: 1e6), "s{byuArigzhF??")
     }
+    
+    func testLineStringCoding() throws {
+        let coordinates: [LocationCoordinate2D] = [
+            .init(latitude: 0, longitude: 0),
+            .init(latitude: 1, longitude: 1),
+            .init(latitude: -1, longitude: -1),
+        ]
+        let options = RouteOptions(coordinates: coordinates)
+        options.shapeFormat = .geoJSON
+        
+        let json: [String: Any?] = [
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 1], [-1, -1]],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json, options: [])
+        
+        let decoder = JSONDecoder()
+        decoder.userInfo[.options] = options
+        let polyLineString = try decoder.decode(PolyLineString.self, from: data)
+        guard case .lineString = polyLineString else {
+            XCTFail("Should decode polyline/linestring as linestring.")
+            return
+        }
+        
+        let encoder = JSONEncoder()
+        encoder.userInfo[.options] = options
+        let reencodedData = try encoder.encode(polyLineString)
+        let reencodedJSON = try JSONSerialization.jsonObject(with: reencodedData, options: [])
+        XCTAssertEqual(json as NSDictionary, reencodedJSON as? NSDictionary)
+    }
 }


### PR DESCRIPTION
Removed `PolyLineString`’s custom LineString encoding and decoding implementation in favor of Turf’s built-in implementation. This fixes an issue where `PolyLineString` encoded a GeoJSON LineString that was invalid because it was missing the `type` property. (As a result, GeoJSON-formatted Directions API responses were becoming malformed when round-tripped back to JSON.) It will also take advantage of the foreign member support added in mapbox/turf-swift#175 once that gets released.

/cc @mapbox/navigation-ios