### PR TITLE
Fix backwards incompatible associated value in shield implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.3.0
 
-* Added `VisualInstruction.Component.ShieldRepresentation` struct for displaying a highway shield. Renamed `VisualInstruction.Component.image(image:alternativeText:)` to `VisualInstruction.Component.image(image:alternativeText:shield:)`. ([#644](https://github.com/mapbox/mapbox-directions-swift/pull/644))
+* Added `VisualInstruction.Component.ShieldRepresentation` struct for displaying a highway shield. Added `VisualInstruction.Component.ImageRepresentation.shield` property. ([#644](https://github.com/mapbox/mapbox-directions-swift/pull/644))
 
 ## v2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.3.0
 
-* Added `VisualInstruction.Component.ShieldRepresentation` struct for displaying a highway shield. Added `VisualInstruction.Component.ImageRepresentation.shield` property. ([#644](https://github.com/mapbox/mapbox-directions-swift/pull/644))
+* Added `VisualInstruction.Component.ShieldRepresentation` struct for displaying a highway shield. Added `VisualInstruction.Component.ImageRepresentation.shield` property. ([#644](https://github.com/mapbox/mapbox-directions-swift/pull/644), [#647](https://github.com/mapbox/mapbox-directions-swift/pull/647))
 
 ## v2.2.0
 

--- a/Sources/MapboxDirections/VisualInstructionComponent.swift
+++ b/Sources/MapboxDirections/VisualInstructionComponent.swift
@@ -183,11 +183,11 @@ public extension VisualInstruction.Component {
         /**
          Initializes a mapbox shield with the given name, text color, and display ref.
          */
-        public init(baseURL: URL, name: String, textColor: String, code: String) {
+        public init(baseURL: URL, name: String, textColor: String, text: String) {
             self.baseURL = baseURL
             self.name = name
             self.textColor = textColor
-            self.code = code
+            self.text = text
         }
         
         /**
@@ -208,13 +208,13 @@ public extension VisualInstruction.Component {
         /**
          String indicating the route reference code that will be displayed on the shield.
          */
-        public let code: String
+        public let text: String
         
         private enum CodingKeys: String, CodingKey {
             case baseURL = "base_url"
             case name
             case textColor = "text_color"
-            case code = "display_ref"
+            case text = "display_ref"
         }
         
         public init(from decoder: Decoder) throws {
@@ -222,7 +222,7 @@ public extension VisualInstruction.Component {
             baseURL = try container.decode(URL.self, forKey: .baseURL)
             name = try container.decode(String.self, forKey: .name)
             textColor = try container.decode(String.self, forKey: .textColor)
-            code = try container.decode(String.self, forKey: .code)
+            text = try container.decode(String.self, forKey: .text)
         }
         
         public func encode(to encoder: Encoder) throws {
@@ -230,7 +230,7 @@ public extension VisualInstruction.Component {
             try container.encode(baseURL, forKey: .baseURL)
             try container.encode(name, forKey: .name)
             try container.encode(textColor, forKey: .textColor)
-            try container.encode(code, forKey: .code)
+            try container.encode(text, forKey: .text)
         }
     }
 }

--- a/Sources/MapboxDirections/VisualInstructionComponent.swift
+++ b/Sources/MapboxDirections/VisualInstructionComponent.swift
@@ -45,9 +45,8 @@ public extension VisualInstruction {
          
          - parameter image: The component’s preferred image representation.
          - parameter alternativeText: The component’s alternative text representation. Use this representation if the image representation is unavailable or unusable, but consider formatting the text in a special way to distinguish it from an ordinary `.text` component.
-         - parameter shield: Optionally, a structured image representation for displaying a [highway shield](https://en.wikipedia.org/wiki/Highway_shield).
          */
-        case image(image: ImageRepresentation, alternativeText: TextRepresentation, shield: ShieldRepresentation? = nil)
+        case image(image: ImageRepresentation, alternativeText: TextRepresentation)
 
         /**
          The component is an image of a zoomed junction, with a fallback text representation.
@@ -128,14 +127,20 @@ public extension VisualInstruction.Component {
         /**
          Initializes an image representation bearing the image at the given base URL.
          */
-        public init(imageBaseURL: URL?) {
+        public init(imageBaseURL: URL?, shield: ShieldRepresentation? = nil) {
             self.imageBaseURL = imageBaseURL
+            self.shield = shield
         }
         
         /**
          The URL whose path is the prefix of all the possible URLs returned by `imageURL(scale:format:)`.
          */
         public let imageBaseURL: URL?
+        
+        /**
+         Optionally, a structured image representation for displaying a [highway shield](https://en.wikipedia.org/wiki/Highway_shield).
+         */
+        public let shield: ShieldRepresentation?
         
         /**
          Returns a remote URL to the image file that represents the component.
@@ -178,11 +183,11 @@ public extension VisualInstruction.Component {
         /**
          Initializes a mapbox shield with the given name, text color, and display ref.
          */
-        public init(baseURL: URL, name: String, textColor: String, text: String) {
+        public init(baseURL: URL, name: String, textColor: String, code: String) {
             self.baseURL = baseURL
             self.name = name
             self.textColor = textColor
-            self.text = text
+            self.code = code
         }
         
         /**
@@ -203,13 +208,13 @@ public extension VisualInstruction.Component {
         /**
          String indicating the route reference code that will be displayed on the shield.
          */
-        public let text: String
+        public let code: String
         
         private enum CodingKeys: String, CodingKey {
             case baseURL = "base_url"
             case name
             case textColor = "text_color"
-            case text = "display_ref"
+            case code = "display_ref"
         }
         
         public init(from decoder: Decoder) throws {
@@ -217,7 +222,7 @@ public extension VisualInstruction.Component {
             baseURL = try container.decode(URL.self, forKey: .baseURL)
             name = try container.decode(String.self, forKey: .name)
             textColor = try container.decode(String.self, forKey: .textColor)
-            text = try container.decode(String.self, forKey: .text)
+            code = try container.decode(String.self, forKey: .code)
         }
         
         public func encode(to encoder: Encoder) throws {
@@ -225,7 +230,7 @@ public extension VisualInstruction.Component {
             try container.encode(baseURL, forKey: .baseURL)
             try container.encode(name, forKey: .name)
             try container.encode(textColor, forKey: .textColor)
-            try container.encode(text, forKey: .text)
+            try container.encode(code, forKey: .code)
         }
     }
 }
@@ -286,7 +291,6 @@ extension VisualInstruction.Component: Codable {
         let abbreviation = try container.decodeIfPresent(String.self, forKey: .abbreviatedText)
         let abbreviationPriority = try container.decodeIfPresent(Int.self, forKey: .abbreviatedTextPriority)
         let textRepresentation = TextRepresentation(text: text, abbreviation: abbreviation, abbreviationPriority: abbreviationPriority)
-        let shieldRepresentation = try container.decodeIfPresent(ShieldRepresentation.self, forKey: .shield)
         
         switch kind {
         case .delimiter:
@@ -298,8 +302,9 @@ extension VisualInstruction.Component: Codable {
             if let imageBaseURLString = try container.decodeIfPresent(String.self, forKey: .imageBaseURL) {
                 imageBaseURL = URL(string: imageBaseURLString)
             }
-            let imageRepresentation = ImageRepresentation(imageBaseURL: imageBaseURL)
-            self = .image(image: imageRepresentation, alternativeText: textRepresentation, shield: shieldRepresentation)
+            let shieldRepresentation = try container.decodeIfPresent(ShieldRepresentation.self, forKey: .shield)
+            let imageRepresentation = ImageRepresentation(imageBaseURL: imageBaseURL, shield: shieldRepresentation)
+            self = .image(image: imageRepresentation, alternativeText: textRepresentation)
         case .exit:
             self = .exit(text: textRepresentation)
         case .exitCode:
@@ -327,11 +332,11 @@ extension VisualInstruction.Component: Codable {
         case .text(let text):
             try container.encode(Kind.text, forKey: .kind)
             textRepresentation = text
-        case .image(let image, let alternativeText, let shield):
+        case .image(let image, let alternativeText):
             try container.encode(Kind.image, forKey: .kind)
             textRepresentation = alternativeText
             try container.encodeIfPresent(image.imageBaseURL?.absoluteString, forKey: .imageBaseURL)
-            try container.encodeIfPresent(shield, forKey: .shield)
+            try container.encodeIfPresent(image.shield, forKey: .shield)
         case .exit(let text):
             try container.encode(Kind.exit, forKey: .kind)
             textRepresentation = text
@@ -366,11 +371,10 @@ extension VisualInstruction.Component: Equatable {
              (let .exit(lhsText), let .exit(rhsText)),
              (let .exitCode(lhsText), let .exitCode(rhsText)):
             return lhsText == rhsText
-        case (let .image(lhsURL, lhsAlternativeText, lhsShield),
-              let .image(rhsURL, rhsAlternativeText, rhsShield)):
+        case (let .image(lhsURL, lhsAlternativeText),
+              let .image(rhsURL, rhsAlternativeText)):
             return lhsURL == rhsURL
                 && lhsAlternativeText == rhsAlternativeText
-                && lhsShield == rhsShield
         case (let .guidanceView(lhsURL, lhsAlternativeText),
               let .guidanceView(rhsURL, rhsAlternativeText)):
             return lhsURL == rhsURL

--- a/Tests/MapboxDirectionsTests/VisualInstructionComponentTests.swift
+++ b/Tests/MapboxDirectionsTests/VisualInstructionComponentTests.swift
@@ -40,7 +40,7 @@ class VisualInstructionComponentTests: XCTestCase {
         XCTAssertNotNil(component)
         if let component = component {
             switch component {
-            case .image(let image, let alternativeText, let shield):
+            case .image(let image, let alternativeText):
                 XCTAssertEqual(image.imageBaseURL?.absoluteString, "https://s3.amazonaws.com/mapbox/shields/v3/i-95")
                 XCTAssertEqual(image.imageURL(scale: 1, format: .svg)?.absoluteString, "https://s3.amazonaws.com/mapbox/shields/v3/i-95@1x.svg")
                 XCTAssertEqual(image.imageURL(scale: 3, format: .svg)?.absoluteString, "https://s3.amazonaws.com/mapbox/shields/v3/i-95@3x.svg")
@@ -48,18 +48,17 @@ class VisualInstructionComponentTests: XCTestCase {
                 XCTAssertEqual(alternativeText.text, "I 95")
                 XCTAssertNil(alternativeText.abbreviation)
                 XCTAssertNil(alternativeText.abbreviationPriority)
-                XCTAssertEqual(shield?.baseURL, URL(string: "https://api.mapbox.com/styles/v1/")!)
-                XCTAssertEqual(shield?.name, "us-interstate")
-                XCTAssertEqual(shield?.textColor, "white")
-                XCTAssertEqual(shield?.text, "95")
+                XCTAssertEqual(image.shield?.baseURL, URL(string: "https://api.mapbox.com/styles/v1/")!)
+                XCTAssertEqual(image.shield?.name, "us-interstate")
+                XCTAssertEqual(image.shield?.textColor, "white")
+                XCTAssertEqual(image.shield?.code, "95")
             default:
                 XCTFail("Image component should not be decoded as any other kind of component.")
             }
         }
-        
-        component = .image(image: .init(imageBaseURL: URL(string: "https://s3.amazonaws.com/mapbox/shields/v3/i-95")!),
-                           alternativeText: .init(text: "I 95", abbreviation: nil, abbreviationPriority: nil),
-                           shield: .init(baseURL: URL(string: "https://api.mapbox.com/styles/v1/")!, name: "us-interstate", textColor: "white", text: "95"))
+        let shield = VisualInstruction.Component.ShieldRepresentation(baseURL: URL(string: "https://api.mapbox.com/styles/v1/")!, name: "us-interstate", textColor: "white", code: "95")
+        component = .image(image: .init(imageBaseURL: URL(string: "https://s3.amazonaws.com/mapbox/shields/v3/i-95")!, shield: shield),
+                           alternativeText: .init(text: "I 95", abbreviation: nil, abbreviationPriority: nil))
         let encoder = JSONEncoder()
         var encodedData: Data?
         XCTAssertNoThrow(encodedData = try encoder.encode(component))
@@ -91,9 +90,9 @@ class VisualInstructionComponentTests: XCTestCase {
             XCTAssertEqual(shield.baseURL, url)
             XCTAssertEqual(shield.name, "us-interstate")
             XCTAssertEqual(shield.textColor, "white")
-            XCTAssertEqual(shield.text, "95")
+            XCTAssertEqual(shield.code, "95")
         }
-        shield = .init(baseURL: url!, name: "us-interstate", textColor: "white", text: "95")
+        shield = .init(baseURL: url!, name: "us-interstate", textColor: "white", code: "95")
         
         let encoder = JSONEncoder()
         var encodedData: Data?
@@ -126,23 +125,23 @@ class VisualInstructionComponentTests: XCTestCase {
         XCTAssertNotNil(component)
         if let component = component {
             switch component {
-            case .image(let image, let alternativeText, let shield):
+            case .image(let image, let alternativeText):
                 XCTAssertNil(image.imageBaseURL?.absoluteString)
                 XCTAssertEqual(alternativeText.text, "I 95")
                 XCTAssertNil(alternativeText.abbreviation)
                 XCTAssertNil(alternativeText.abbreviationPriority)
-                XCTAssertEqual(shield?.baseURL, URL(string: "https://api.mapbox.com/styles/v1/")!)
-                XCTAssertEqual(shield?.name, "us-interstate")
-                XCTAssertEqual(shield?.textColor, "white")
-                XCTAssertEqual(shield?.text, "95")
+                XCTAssertEqual(image.shield?.baseURL, URL(string: "https://api.mapbox.com/styles/v1/")!)
+                XCTAssertEqual(image.shield?.name, "us-interstate")
+                XCTAssertEqual(image.shield?.textColor, "white")
+                XCTAssertEqual(image.shield?.code, "95")
             default:
                 XCTFail("Image component should not be decoded as any other kind of component.")
             }
         }
         
-        component = .image(image: .init(imageBaseURL: nil),
-                           alternativeText: .init(text: "I 95", abbreviation: nil, abbreviationPriority: nil),
-                           shield: .init(baseURL: URL(string: "https://api.mapbox.com/styles/v1/")!, name: "us-interstate", textColor: "white", text: "95"))
+        let shield = VisualInstruction.Component.ShieldRepresentation(baseURL: URL(string: "https://api.mapbox.com/styles/v1/")!, name: "us-interstate", textColor: "white", code: "95")
+        component = .image(image: .init(imageBaseURL: nil, shield: shield),
+                           alternativeText: .init(text: "I 95", abbreviation: nil, abbreviationPriority: nil))
         let encoder = JSONEncoder()
         var encodedData: Data?
         XCTAssertNoThrow(encodedData = try encoder.encode(component))

--- a/Tests/MapboxDirectionsTests/VisualInstructionComponentTests.swift
+++ b/Tests/MapboxDirectionsTests/VisualInstructionComponentTests.swift
@@ -51,12 +51,12 @@ class VisualInstructionComponentTests: XCTestCase {
                 XCTAssertEqual(image.shield?.baseURL, URL(string: "https://api.mapbox.com/styles/v1/")!)
                 XCTAssertEqual(image.shield?.name, "us-interstate")
                 XCTAssertEqual(image.shield?.textColor, "white")
-                XCTAssertEqual(image.shield?.code, "95")
+                XCTAssertEqual(image.shield?.text, "95")
             default:
                 XCTFail("Image component should not be decoded as any other kind of component.")
             }
         }
-        let shield = VisualInstruction.Component.ShieldRepresentation(baseURL: URL(string: "https://api.mapbox.com/styles/v1/")!, name: "us-interstate", textColor: "white", code: "95")
+        let shield = VisualInstruction.Component.ShieldRepresentation(baseURL: URL(string: "https://api.mapbox.com/styles/v1/")!, name: "us-interstate", textColor: "white", text: "95")
         component = .image(image: .init(imageBaseURL: URL(string: "https://s3.amazonaws.com/mapbox/shields/v3/i-95")!, shield: shield),
                            alternativeText: .init(text: "I 95", abbreviation: nil, abbreviationPriority: nil))
         let encoder = JSONEncoder()
@@ -90,9 +90,9 @@ class VisualInstructionComponentTests: XCTestCase {
             XCTAssertEqual(shield.baseURL, url)
             XCTAssertEqual(shield.name, "us-interstate")
             XCTAssertEqual(shield.textColor, "white")
-            XCTAssertEqual(shield.code, "95")
+            XCTAssertEqual(shield.text, "95")
         }
-        shield = .init(baseURL: url!, name: "us-interstate", textColor: "white", code: "95")
+        shield = .init(baseURL: url!, name: "us-interstate", textColor: "white", text: "95")
         
         let encoder = JSONEncoder()
         var encodedData: Data?
@@ -133,13 +133,13 @@ class VisualInstructionComponentTests: XCTestCase {
                 XCTAssertEqual(image.shield?.baseURL, URL(string: "https://api.mapbox.com/styles/v1/")!)
                 XCTAssertEqual(image.shield?.name, "us-interstate")
                 XCTAssertEqual(image.shield?.textColor, "white")
-                XCTAssertEqual(image.shield?.code, "95")
+                XCTAssertEqual(image.shield?.text, "95")
             default:
                 XCTFail("Image component should not be decoded as any other kind of component.")
             }
         }
         
-        let shield = VisualInstruction.Component.ShieldRepresentation(baseURL: URL(string: "https://api.mapbox.com/styles/v1/")!, name: "us-interstate", textColor: "white", code: "95")
+        let shield = VisualInstruction.Component.ShieldRepresentation(baseURL: URL(string: "https://api.mapbox.com/styles/v1/")!, name: "us-interstate", textColor: "white", text: "95")
         component = .image(image: .init(imageBaseURL: nil, shield: shield),
                            alternativeText: .init(text: "I 95", abbreviation: nil, abbreviationPriority: nil))
         let encoder = JSONEncoder()


### PR DESCRIPTION
This PR fixes #646 by making `shield` an optional property of `VisualInstruction.Component.ImageRepresentation`.

cc/ @1ec5 @bamx23