### PR TITLE
Options & Credentials decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added `VisualInstruction.Component.ShieldRepresentation` struct and the `VisualInstruction.Component.ImageRepresentation.shield` property containing metadata for displaying a highway shield consistent with map styles used by the Mapbox Maps SDK. ([#644](https://github.com/mapbox/mapbox-directions-swift/pull/644), [#647](https://github.com/mapbox/mapbox-directions-swift/pull/647))
 * Added a `RouteLeg.viaWaypoints` property that lists the non-leg-separating waypoints (also known as “silent waypoints”) along a `RouteLeg`. Previously, you had to filter `DirectionsOptions.waypoints` to include only the items whose `Waypoints.separatesLegs` property was set to `true`, then zip them with `RouteResponse.routes`. This approach still works in some cases but is not guaranteed to be reliable for all Mapbox Directions API responses in the future. ([#656](https://github.com/mapbox/mapbox-directions-swift/pull/656))
+* Added `DirectionsOptions(url:)`, `RouteOptions.restore(from:)` and `DirectionsOptions.restore(from:)` methods for deserializing corresponding options object using appropriate request URL. ([#655](https://github.com/mapbox/mapbox-directions-swift/pull/655))
 
 ## v2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added `VisualInstruction.Component.ShieldRepresentation` struct and the `VisualInstruction.Component.ImageRepresentation.shield` property containing metadata for displaying a highway shield consistent with map styles used by the Mapbox Maps SDK. ([#644](https://github.com/mapbox/mapbox-directions-swift/pull/644), [#647](https://github.com/mapbox/mapbox-directions-swift/pull/647))
 * Added a `RouteLeg.viaWaypoints` property that lists the non-leg-separating waypoints (also known as “silent waypoints”) along a `RouteLeg`. Previously, you had to filter `DirectionsOptions.waypoints` to include only the items whose `Waypoints.separatesLegs` property was set to `true`, then zip them with `RouteResponse.routes`. This approach still works in some cases but is not guaranteed to be reliable for all Mapbox Directions API responses in the future. ([#656](https://github.com/mapbox/mapbox-directions-swift/pull/656))
-* Added `DirectionsOptions(url:)`, `RouteOptions.restore(from:)` and `DirectionsOptions.restore(from:)` methods for deserializing corresponding options object using appropriate request URL. ([#655](https://github.com/mapbox/mapbox-directions-swift/pull/655))
+* Added `DirectionsOptions(url:)`, `RouteOptions(url:)` and extended existing `DirectionsOptions(waypoints:profileIdentifier:queryItems:)`, `RouteOptions(waypoints:profileIdentifier:queryItems:)`, `MatchOptions(waypoints:profileIdentifier:queryItems:)` and related convenience init methods for deserializing corresponding options object using appropriate request URL or it's query items. ([#655](https://github.com/mapbox/mapbox-directions-swift/pull/655))
 
 ## v2.2.0
 

--- a/Sources/MapboxDirections/Credentials.swift
+++ b/Sources/MapboxDirections/Credentials.swift
@@ -63,6 +63,17 @@ public struct Credentials: Equatable {
             self.host = URL(string: "https://api.mapbox.com")!
         }
     }
+    
+    public init(requestURL url: URL) {
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let accessToken = components?
+            .queryItems?
+            .first { $0.name == "access_token" }?
+            .value
+        components?.path = "/"
+        components?.queryItems = nil
+        self.init(accessToken: accessToken, host: components?.url)
+    }
 }
 
 @available(*, deprecated, renamed: "Credentials")

--- a/Sources/MapboxDirections/Credentials.swift
+++ b/Sources/MapboxDirections/Credentials.swift
@@ -64,6 +64,12 @@ public struct Credentials: Equatable {
         }
     }
     
+    /**
+     :nodoc:
+     Attempts to get `host` and `accessToken` from provided URL to create `Credentials` instance.
+     
+     If it is impossible to extract parameter(s) - default values will be used.
+     */
     public init(requestURL url: URL) {
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         let accessToken = components?

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -245,7 +245,7 @@ open class DirectionsOptions: Codable {
         }
             
         guard waypoints.count >= 2 else {
-                    return nil
+            return nil
         }
         
         let profileIdentifier = ProfileIdentifier(rawValue: url.pathComponents.dropLast().suffix(2).joined(separator: "/"))

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Polyline
+import Turf
 
 /**
  Maximum length of an HTTP request URL for the purposes of switching from GET to
@@ -126,6 +127,44 @@ open class DirectionsOptions: Codable {
     required public init(waypoints: [Waypoint], profileIdentifier: ProfileIdentifier? = nil) {
         self.waypoints = waypoints
         self.profileIdentifier = profileIdentifier ?? .automobile
+    }
+    
+    /**
+     Creates new options object by deserializing given `url`
+     
+     Initialization fails if it is unable to extract `waypoints` list and `profileIdentifier`. If other properties are failed to decode - it will just skip them.
+     
+     - parameter url: An URL, used to make a route request.
+     */
+    public convenience init?(url: URL) {
+        guard url.pathComponents.count >= 3 else {
+                    return nil
+        }
+        
+        let waypointsString = url.lastPathComponent.replacingOccurrences(of: ".json", with: "")
+        let waypoints: [Waypoint] = waypointsString.components(separatedBy: ";").compactMap {
+            let coordinates = $0.components(separatedBy: ",")
+            guard coordinates.count == 2,
+                  let latitudeString = coordinates.last,
+                  let longitudeString = coordinates.first,
+                  let latitude = LocationDegrees(latitudeString),
+                  let longitude = LocationDegrees(longitudeString) else {
+                      return nil
+            }
+            return Waypoint(coordinate: .init(latitude: latitude,
+                                              longitude: longitude))
+        }
+            
+        guard waypoints.count >= 2 else {
+                    return nil
+        }
+        
+        let profileIdentifier = ProfileIdentifier(rawValue: url.pathComponents.dropLast().suffix(2).joined(separator: "/"))
+        
+        self.init(waypoints: waypoints,
+                  profileIdentifier: profileIdentifier)
+        
+        restore(from: url)
     }
     
     
@@ -367,6 +406,98 @@ open class DirectionsOptions: Codable {
         }
         
         return queryItems
+    }
+    
+    /**
+     Method to deserialize options parameters from given `url`.
+     
+     - parameter url: An URL, used to make a route request.
+     */
+    open func restore(from url: URL) {
+        guard let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: true)?.queryItems else {
+            return
+        }
+        
+        let mappedQueryItems = Dictionary<String, String>(uniqueKeysWithValues: queryItems.compactMap {
+            guard let value = $0.value else { return nil }
+            return ($0.name, value)
+        })
+        
+        if let mappedValue = mappedQueryItems[CodingKeys.shapeFormat.stringValue],
+           let shapeFormat = RouteShapeFormat(rawValue: mappedValue) {
+            self.shapeFormat = shapeFormat
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.routeShapeResolution.stringValue],
+           let routeShapeResolution = RouteShapeResolution(rawValue: mappedValue) {
+            self.routeShapeResolution = routeShapeResolution
+        }
+        if mappedQueryItems[CodingKeys.includesSteps.stringValue] == "true" {
+            self.includesSteps = true
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.locale.stringValue] {
+            self.locale = Locale(identifier: mappedValue)
+        }
+        if mappedQueryItems[CodingKeys.includesSpokenInstructions.stringValue] == "true" {
+            self.includesSpokenInstructions = true
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.distanceMeasurementSystem.stringValue],
+           let measurementSystem = MeasurementSystem(rawValue: mappedValue) {
+            self.distanceMeasurementSystem = measurementSystem
+        }
+        if mappedQueryItems[CodingKeys.includesVisualInstructions.stringValue] == "true" {
+            self.includesVisualInstructions = true
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.attributeOptions.stringValue],
+           let attributeOptions = AttributeOptions(descriptions: mappedValue.components(separatedBy: ",")) {
+            self.attributeOptions = attributeOptions
+        }
+        if let mappedValue = mappedQueryItems["waypoints"] {
+            let indicies = mappedValue.components(separatedBy: ";").compactMap { Int($0) }
+            if !indicies.isEmpty {
+                waypoints.enumerated().forEach {
+                    $0.element.separatesLegs = indicies.contains($0.offset)
+                }
+            }
+        }
+        
+        let waypointsData = [mappedQueryItems["approaches"]?.components(separatedBy: ";"),
+                             mappedQueryItems["bearings"]?.components(separatedBy: ";"),
+                             mappedQueryItems["radiuses"]?.components(separatedBy: ";"),
+                             mappedQueryItems["waypoint_names"]?.components(separatedBy: ";"),
+                             mappedQueryItems["snapping_include_closures"]?.components(separatedBy: ";")
+        ] as [[String]?]
+        
+        let getElement: ((_ array: [String]?, _ index: Int) -> String?) = { array, index in
+            if array?.count ?? -1 > index {
+                return array?[index]
+            }
+            return nil
+        }
+        
+        waypoints.enumerated().forEach {
+            if let approach = getElement(waypointsData[0], $0.offset) {
+                $0.element.allowsArrivingOnOppositeSide = approach == "unrestricted" ? true : false
+            }
+            
+            if let descriptions = waypointsData[1]?[$0.offset].components(separatedBy: ",") {
+                $0.element.heading = LocationDirection(descriptions.first!)
+                $0.element.headingAccuracy = LocationDirection(descriptions.last!)
+            }
+            
+            if let accuracy = waypointsData[2]?[$0.offset] {
+                $0.element.coordinateAccuracy = LocationAccuracy(accuracy)
+            }
+            
+            if let snaps = waypointsData[4]?[$0.offset] {
+                $0.element.allowsSnappingToClosedRoad = snaps == "true"
+            }
+        }
+        
+        waypoints.filter { $0.separatesLegs }.enumerated().forEach {
+            if let name = waypointsData[3]?[$0.offset] {
+                $0.element.name = name
+            }
+        }
     }
     
     var bearings: String? {

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -123,10 +123,96 @@ open class DirectionsOptions: Codable {
 
      - parameter waypoints: An array of `Waypoint` objects representing locations that the route should visit in chronological order. The array should contain at least two waypoints (the source and destination) and at most 25 waypoints. (Some profiles, such as `ProfileIdentifier.automobileAvoidingTraffic`, [may have lower limits](https://docs.mapbox.com/api/navigation/#directions).)
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. `ProfileIdentifier.automobile` is used by default.
+     - parameter queryItems: URL query items to be parsed and applied as configuration to the resulting options.
      */
-    required public init(waypoints: [Waypoint], profileIdentifier: ProfileIdentifier? = nil) {
+    required public init(waypoints: [Waypoint], profileIdentifier: ProfileIdentifier? = nil, queryItems: [URLQueryItem]? = nil) {
         self.waypoints = waypoints
         self.profileIdentifier = profileIdentifier ?? .automobile
+        
+        guard let queryItems = queryItems else {
+            return
+        }
+        
+        let mappedQueryItems = Dictionary<String, String>(uniqueKeysWithValues: queryItems.compactMap {
+            guard let value = $0.value else { return nil }
+            return ($0.name, value)
+        })
+        
+        if let mappedValue = mappedQueryItems[CodingKeys.shapeFormat.stringValue],
+           let shapeFormat = RouteShapeFormat(rawValue: mappedValue) {
+            self.shapeFormat = shapeFormat
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.routeShapeResolution.stringValue],
+           let routeShapeResolution = RouteShapeResolution(rawValue: mappedValue) {
+            self.routeShapeResolution = routeShapeResolution
+        }
+        if mappedQueryItems[CodingKeys.includesSteps.stringValue] == "true" {
+            self.includesSteps = true
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.locale.stringValue] {
+            self.locale = Locale(identifier: mappedValue)
+        }
+        if mappedQueryItems[CodingKeys.includesSpokenInstructions.stringValue] == "true" {
+            self.includesSpokenInstructions = true
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.distanceMeasurementSystem.stringValue],
+           let measurementSystem = MeasurementSystem(rawValue: mappedValue) {
+            self.distanceMeasurementSystem = measurementSystem
+        }
+        if mappedQueryItems[CodingKeys.includesVisualInstructions.stringValue] == "true" {
+            self.includesVisualInstructions = true
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.attributeOptions.stringValue],
+           let attributeOptions = AttributeOptions(descriptions: mappedValue.components(separatedBy: ",")) {
+            self.attributeOptions = attributeOptions
+        }
+        if let mappedValue = mappedQueryItems["waypoints"] {
+            let indicies = mappedValue.components(separatedBy: ";").compactMap { Int($0) }
+            if !indicies.isEmpty {
+                waypoints.enumerated().forEach {
+                    $0.element.separatesLegs = indicies.contains($0.offset)
+                }
+            }
+        }
+        
+        let waypointsData = [mappedQueryItems["approaches"]?.components(separatedBy: ";"),
+                             mappedQueryItems["bearings"]?.components(separatedBy: ";"),
+                             mappedQueryItems["radiuses"]?.components(separatedBy: ";"),
+                             mappedQueryItems["waypoint_names"]?.components(separatedBy: ";"),
+                             mappedQueryItems["snapping_include_closures"]?.components(separatedBy: ";")
+        ] as [[String]?]
+        
+        let getElement: ((_ array: [String]?, _ index: Int) -> String?) = { array, index in
+            if array?.count ?? -1 > index {
+                return array?[index]
+            }
+            return nil
+        }
+        
+        waypoints.enumerated().forEach {
+            if let approach = getElement(waypointsData[0], $0.offset) {
+                $0.element.allowsArrivingOnOppositeSide = approach == "unrestricted" ? true : false
+            }
+            
+            if let descriptions = waypointsData[1]?[$0.offset].components(separatedBy: ",") {
+                $0.element.heading = LocationDirection(descriptions.first!)
+                $0.element.headingAccuracy = LocationDirection(descriptions.last!)
+            }
+            
+            if let accuracy = waypointsData[2]?[$0.offset] {
+                $0.element.coordinateAccuracy = LocationAccuracy(accuracy)
+            }
+            
+            if let snaps = waypointsData[4]?[$0.offset] {
+                $0.element.allowsSnappingToClosedRoad = snaps == "true"
+            }
+        }
+        
+        waypoints.filter { $0.separatesLegs }.enumerated().forEach {
+            if let name = waypointsData[3]?[$0.offset] {
+                $0.element.name = name
+            }
+        }
     }
     
     /**
@@ -162,9 +248,8 @@ open class DirectionsOptions: Codable {
         let profileIdentifier = ProfileIdentifier(rawValue: url.pathComponents.dropLast().suffix(2).joined(separator: "/"))
         
         self.init(waypoints: waypoints,
-                  profileIdentifier: profileIdentifier)
-        
-        restore(from: url)
+                  profileIdentifier: profileIdentifier,
+                  queryItems: URLComponents(url: url, resolvingAgainstBaseURL: true)?.queryItems)
     }
     
     
@@ -408,97 +493,6 @@ open class DirectionsOptions: Codable {
         return queryItems
     }
     
-    /**
-     Method to deserialize options parameters from given `url`.
-     
-     - parameter url: An URL, used to make a route request.
-     */
-    open func restore(from url: URL) {
-        guard let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: true)?.queryItems else {
-            return
-        }
-        
-        let mappedQueryItems = Dictionary<String, String>(uniqueKeysWithValues: queryItems.compactMap {
-            guard let value = $0.value else { return nil }
-            return ($0.name, value)
-        })
-        
-        if let mappedValue = mappedQueryItems[CodingKeys.shapeFormat.stringValue],
-           let shapeFormat = RouteShapeFormat(rawValue: mappedValue) {
-            self.shapeFormat = shapeFormat
-        }
-        if let mappedValue = mappedQueryItems[CodingKeys.routeShapeResolution.stringValue],
-           let routeShapeResolution = RouteShapeResolution(rawValue: mappedValue) {
-            self.routeShapeResolution = routeShapeResolution
-        }
-        if mappedQueryItems[CodingKeys.includesSteps.stringValue] == "true" {
-            self.includesSteps = true
-        }
-        if let mappedValue = mappedQueryItems[CodingKeys.locale.stringValue] {
-            self.locale = Locale(identifier: mappedValue)
-        }
-        if mappedQueryItems[CodingKeys.includesSpokenInstructions.stringValue] == "true" {
-            self.includesSpokenInstructions = true
-        }
-        if let mappedValue = mappedQueryItems[CodingKeys.distanceMeasurementSystem.stringValue],
-           let measurementSystem = MeasurementSystem(rawValue: mappedValue) {
-            self.distanceMeasurementSystem = measurementSystem
-        }
-        if mappedQueryItems[CodingKeys.includesVisualInstructions.stringValue] == "true" {
-            self.includesVisualInstructions = true
-        }
-        if let mappedValue = mappedQueryItems[CodingKeys.attributeOptions.stringValue],
-           let attributeOptions = AttributeOptions(descriptions: mappedValue.components(separatedBy: ",")) {
-            self.attributeOptions = attributeOptions
-        }
-        if let mappedValue = mappedQueryItems["waypoints"] {
-            let indicies = mappedValue.components(separatedBy: ";").compactMap { Int($0) }
-            if !indicies.isEmpty {
-                waypoints.enumerated().forEach {
-                    $0.element.separatesLegs = indicies.contains($0.offset)
-                }
-            }
-        }
-        
-        let waypointsData = [mappedQueryItems["approaches"]?.components(separatedBy: ";"),
-                             mappedQueryItems["bearings"]?.components(separatedBy: ";"),
-                             mappedQueryItems["radiuses"]?.components(separatedBy: ";"),
-                             mappedQueryItems["waypoint_names"]?.components(separatedBy: ";"),
-                             mappedQueryItems["snapping_include_closures"]?.components(separatedBy: ";")
-        ] as [[String]?]
-        
-        let getElement: ((_ array: [String]?, _ index: Int) -> String?) = { array, index in
-            if array?.count ?? -1 > index {
-                return array?[index]
-            }
-            return nil
-        }
-        
-        waypoints.enumerated().forEach {
-            if let approach = getElement(waypointsData[0], $0.offset) {
-                $0.element.allowsArrivingOnOppositeSide = approach == "unrestricted" ? true : false
-            }
-            
-            if let descriptions = waypointsData[1]?[$0.offset].components(separatedBy: ",") {
-                $0.element.heading = LocationDirection(descriptions.first!)
-                $0.element.headingAccuracy = LocationDirection(descriptions.last!)
-            }
-            
-            if let accuracy = waypointsData[2]?[$0.offset] {
-                $0.element.coordinateAccuracy = LocationAccuracy(accuracy)
-            }
-            
-            if let snaps = waypointsData[4]?[$0.offset] {
-                $0.element.allowsSnappingToClosedRoad = snaps == "true"
-            }
-        }
-        
-        waypoints.filter { $0.separatesLegs }.enumerated().forEach {
-            if let name = waypointsData[3]?[$0.offset] {
-                $0.element.name = name
-            }
-        }
-    }
     
     var bearings: String? {
         guard waypoints.contains(where: { $0.heading ?? -1 >= 0 }) else {

--- a/Sources/MapboxDirections/MapMatching/MatchOptions.swift
+++ b/Sources/MapboxDirections/MapMatching/MatchOptions.swift
@@ -18,12 +18,13 @@ open class MatchOptions: DirectionsOptions {
 
      - parameter locations: An array of `CLLocation` objects representing locations to attempt to match against the road network. The array should contain at least two locations (the source and destination) and at most 100 locations. (Some profiles, such as `ProfileIdentifier.automobileAvoidingTraffic`, [may have lower limits](https://docs.mapbox.com/api/navigation/#directions).)
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. `ProfileIdentifier.automobile` is used by default.
+     - parameter queryItems: URL query items to be parsed and applied as configuration to the resulting options.
      */
-    public convenience init(locations: [CLLocation], profileIdentifier: ProfileIdentifier? = nil) {
+    public convenience init(locations: [CLLocation], profileIdentifier: ProfileIdentifier? = nil, queryItems: [URLQueryItem]? = nil) {
         let waypoints = locations.map {
             Waypoint(location: $0)
         }
-        self.init(waypoints: waypoints, profileIdentifier: profileIdentifier)
+        self.init(waypoints: waypoints, profileIdentifier: profileIdentifier, queryItems: queryItems)
     }
     #endif
 
@@ -32,16 +33,39 @@ open class MatchOptions: DirectionsOptions {
 
      - parameter coordinates: An array of geographic coordinates representing locations to attempt to match against the road network. The array should contain at least two locations (the source and destination) and at most 100 locations. (Some profiles, such as `ProfileIdentifier.automobileAvoidingTraffic`, [may have lower limits](https://docs.mapbox.com/api/navigation/#directions).) Each coordinate is converted into a `Waypoint` object.
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. `ProfileIdentifier.automobile` is used by default.
+     - parameter queryItems: URL query items to be parsed and applied as configuration to the resulting options.
      */
-    public convenience init(coordinates: [LocationCoordinate2D], profileIdentifier: ProfileIdentifier? = nil) {
+    public convenience init(coordinates: [LocationCoordinate2D], profileIdentifier: ProfileIdentifier? = nil, queryItems: [URLQueryItem]? = nil) {
         let waypoints = coordinates.map {
             Waypoint(coordinate: $0)
         }
-        self.init(waypoints: waypoints, profileIdentifier: profileIdentifier)
+        self.init(waypoints: waypoints, profileIdentifier: profileIdentifier, queryItems: queryItems)
     }
 
-    public required init(waypoints: [Waypoint], profileIdentifier: ProfileIdentifier? = nil) {
-        super.init(waypoints: waypoints, profileIdentifier: profileIdentifier)
+    public required init(waypoints: [Waypoint], profileIdentifier: ProfileIdentifier? = nil, queryItems: [URLQueryItem]? = nil) {
+        super.init(waypoints: waypoints, profileIdentifier: profileIdentifier, queryItems: queryItems)
+        
+        guard let queryItems = queryItems else {
+            return
+        }
+        
+        let mappedQueryItems = Dictionary<String, String>(uniqueKeysWithValues: queryItems.compactMap {
+            guard let value = $0.value else { return nil }
+            return ($0.name, value)
+        })
+        
+        if mappedQueryItems[CodingKeys.resamplesTraces.stringValue] == "true" {
+            self.resamplesTraces = true
+        }
+        
+        if let mappedValue = mappedQueryItems["waypoints"] {
+            let indicies = mappedValue.components(separatedBy: ";").compactMap { Int($0) }
+            if !indicies.isEmpty {
+                waypoints.enumerated().forEach {
+                    $0.element.separatesLegs = indicies.contains($0.offset)
+                }
+            }
+        }
     }
     
     private enum CodingKeys: String, CodingKey {

--- a/Sources/MapboxDirections/MapMatching/MatchOptions.swift
+++ b/Sources/MapboxDirections/MapMatching/MatchOptions.swift
@@ -49,9 +49,12 @@ open class MatchOptions: DirectionsOptions {
             return
         }
         
-        let mappedQueryItems = Dictionary<String, String>(uniqueKeysWithValues: queryItems.compactMap {
+        let mappedQueryItems = Dictionary<String, String>(queryItems.compactMap {
             guard let value = $0.value else { return nil }
             return ($0.name, value)
+        },
+                   uniquingKeysWith: { (_, latestValue) in
+            return latestValue
         })
         
         if mappedQueryItems[CodingKeys.resamplesTraces.stringValue] == "true" {

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -28,9 +28,12 @@ open class RouteOptions: DirectionsOptions {
             return
         }
         
-        let mappedQueryItems = Dictionary<String, String>(uniqueKeysWithValues: queryItems.compactMap {
+        let mappedQueryItems = Dictionary<String, String>(queryItems.compactMap {
             guard let value = $0.value else { return nil }
             return ($0.name, value)
+        },
+                   uniquingKeysWith: { (_, latestValue) in
+            return latestValue
         })
         
         if mappedQueryItems[CodingKeys.includesAlternativeRoutes.stringValue] == "true" {

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -291,10 +291,7 @@ open class RouteOptions: DirectionsOptions {
         }
         
         if !roadClassesToAllow.isEmpty && roadClassesToAllow.isSubset(of: [.highOccupancyVehicle2, .highOccupancyVehicle3, .highOccupancyToll]) {
-            let allRoadClasses = roadClassesToAllow.description.components(separatedBy: ",").filter { !$0.isEmpty }
-            allRoadClasses.forEach { roadClass in
-                params.append(URLQueryItem(name: CodingKeys.roadClassesToAllow.stringValue, value: roadClass))
-            }
+            params.append(URLQueryItem(name: CodingKeys.roadClassesToAllow.stringValue, value: roadClassesToAllow.description))
         }
         
         if refreshingEnabled && profileIdentifier == .automobileAvoidingTraffic {
@@ -321,6 +318,76 @@ open class RouteOptions: DirectionsOptions {
         }
 
         return params + super.urlQueryItems
+    }
+    
+    /**
+     Method to deserialize options parameters from given `url`.
+     
+     - parameter url: An URL, used to make a route request.
+     */
+    override open func restore(from url: URL) {
+        super.restore(from: url)
+        
+        guard let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: true)?.queryItems else {
+            return
+        }
+        
+        let mappedQueryItems = Dictionary<String, String>(uniqueKeysWithValues: queryItems.compactMap {
+            guard let value = $0.value else { return nil }
+            return ($0.name, value)
+        })
+        
+        if mappedQueryItems[CodingKeys.includesAlternativeRoutes.stringValue] == "true" {
+            self.includesAlternativeRoutes = true
+        }
+        if mappedQueryItems[CodingKeys.includesExitRoundaboutManeuver.stringValue] == "true" {
+            self.includesExitRoundaboutManeuver = true
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.alleyPriority.stringValue],
+           let alleyPriority = Double(mappedValue) {
+            self.alleyPriority = DirectionsPriority(rawValue: alleyPriority)
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.walkwayPriority.stringValue],
+           let walkwayPriority = Double(mappedValue) {
+            self.walkwayPriority = DirectionsPriority(rawValue: walkwayPriority)
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.speed.stringValue],
+           let speed = LocationSpeed(mappedValue) {
+            self.speed = speed
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.roadClassesToAvoid.stringValue],
+           let roadClassesToAvoid = RoadClasses(descriptions:mappedValue.components(separatedBy: ",")) {
+            self.roadClassesToAvoid = roadClassesToAvoid
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.roadClassesToAllow.stringValue],
+           let roadClassesToAllow = RoadClasses(descriptions:mappedValue.components(separatedBy: ",")) {
+            self.roadClassesToAllow = roadClassesToAllow
+        }
+        if mappedQueryItems[CodingKeys.refreshingEnabled.stringValue] == "true" && profileIdentifier == .automobileAvoidingTraffic {
+            self.refreshingEnabled = true
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.waypointTargets.stringValue] {
+            zip(waypoints.filter { $0.separatesLegs },
+                mappedValue.components(separatedBy: ";")).forEach {
+                let coordinatesComponents = $1.components(separatedBy: ",")
+                if coordinatesComponents.count == 2 {
+                    $0.targetCoordinate = LocationCoordinate2D(latitude: LocationDegrees(coordinatesComponents.last!)!,
+                                                               longitude: LocationDegrees(coordinatesComponents.first!)!)
+                }
+            }
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.initialManeuverAvoidanceRadius.stringValue],
+           let initialManeuverAvoidanceRadius = LocationDistance(mappedValue) {
+            self.initialManeuverAvoidanceRadius = initialManeuverAvoidanceRadius
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.maximumHeight.stringValue],
+           let doubleValue = Double(mappedValue) {
+            self.maximumHeight = Measurement(value: doubleValue, unit: UnitLength.meters)
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.maximumWidth.stringValue],
+           let doubleValue = Double(mappedValue) {
+            self.maximumWidth = Measurement(value: doubleValue, unit: UnitLength.meters)
+        }
     }
 }
 

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -17,11 +17,73 @@ open class RouteOptions: DirectionsOptions {
 
      - parameter waypoints: An array of `Waypoint` objects representing locations that the route should visit in chronological order. The array should contain at least two waypoints (the source and destination) and at most 25 waypoints. (Some profiles, such as `ProfileIdentifier.automobileAvoidingTraffic`, [may have lower limits](https://www.mapbox.com/api-documentation/#directions).)
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. `ProfileIdentifier.automobile` is used by default.
+     - parameter queryItems: URL query items to be parsed and applied as configuration to the resulting options.
      */
-    public required init(waypoints: [Waypoint], profileIdentifier: ProfileIdentifier? = nil) {
+    public required init(waypoints: [Waypoint], profileIdentifier: ProfileIdentifier? = nil, queryItems: [URLQueryItem]? = nil) {
         let profilesDisallowingUTurns: [ProfileIdentifier] = [.automobile, .automobileAvoidingTraffic]
         allowsUTurnAtWaypoint = !profilesDisallowingUTurns.contains(profileIdentifier ?? .automobile)
-        super.init(waypoints: waypoints, profileIdentifier: profileIdentifier)
+        super.init(waypoints: waypoints, profileIdentifier: profileIdentifier, queryItems: queryItems)
+        
+        guard let queryItems = queryItems else {
+            return
+        }
+        
+        let mappedQueryItems = Dictionary<String, String>(uniqueKeysWithValues: queryItems.compactMap {
+            guard let value = $0.value else { return nil }
+            return ($0.name, value)
+        })
+        
+        if mappedQueryItems[CodingKeys.includesAlternativeRoutes.stringValue] == "true" {
+            self.includesAlternativeRoutes = true
+        }
+        if mappedQueryItems[CodingKeys.includesExitRoundaboutManeuver.stringValue] == "true" {
+            self.includesExitRoundaboutManeuver = true
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.alleyPriority.stringValue],
+           let alleyPriority = Double(mappedValue) {
+            self.alleyPriority = DirectionsPriority(rawValue: alleyPriority)
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.walkwayPriority.stringValue],
+           let walkwayPriority = Double(mappedValue) {
+            self.walkwayPriority = DirectionsPriority(rawValue: walkwayPriority)
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.speed.stringValue],
+           let speed = LocationSpeed(mappedValue) {
+            self.speed = speed
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.roadClassesToAvoid.stringValue],
+           let roadClassesToAvoid = RoadClasses(descriptions:mappedValue.components(separatedBy: ",")) {
+            self.roadClassesToAvoid = roadClassesToAvoid
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.roadClassesToAllow.stringValue],
+           let roadClassesToAllow = RoadClasses(descriptions:mappedValue.components(separatedBy: ",")) {
+            self.roadClassesToAllow = roadClassesToAllow
+        }
+        if mappedQueryItems[CodingKeys.refreshingEnabled.stringValue] == "true" && profileIdentifier == .automobileAvoidingTraffic {
+            self.refreshingEnabled = true
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.waypointTargets.stringValue] {
+            zip(waypoints.filter { $0.separatesLegs },
+                mappedValue.components(separatedBy: ";")).forEach {
+                let coordinatesComponents = $1.components(separatedBy: ",")
+                if coordinatesComponents.count == 2 {
+                    $0.targetCoordinate = LocationCoordinate2D(latitude: LocationDegrees(coordinatesComponents.last!)!,
+                                                               longitude: LocationDegrees(coordinatesComponents.first!)!)
+                }
+            }
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.initialManeuverAvoidanceRadius.stringValue],
+           let initialManeuverAvoidanceRadius = LocationDistance(mappedValue) {
+            self.initialManeuverAvoidanceRadius = initialManeuverAvoidanceRadius
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.maximumHeight.stringValue],
+           let doubleValue = Double(mappedValue) {
+            self.maximumHeight = Measurement(value: doubleValue, unit: UnitLength.meters)
+        }
+        if let mappedValue = mappedQueryItems[CodingKeys.maximumWidth.stringValue],
+           let doubleValue = Double(mappedValue) {
+            self.maximumWidth = Measurement(value: doubleValue, unit: UnitLength.meters)
+        }
     }
 
     #if canImport(CoreLocation)
@@ -32,10 +94,11 @@ open class RouteOptions: DirectionsOptions {
 
      - parameter locations: An array of `CLLocation` objects representing locations that the route should visit in chronological order. The array should contain at least two locations (the source and destination) and at most 25 locations. Each location object is converted into a `Waypoint` object. This class respects the `CLLocation` class’s `coordinate` and `horizontalAccuracy` properties, converting them into the `Waypoint` class’s `coordinate` and `coordinateAccuracy` properties, respectively.
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. `ProfileIdentifier.automobile` is used by default.
+     - parameter queryItems: URL query items to be parsed and applied as configuration to the resulting options.
      */
-    public convenience init(locations: [CLLocation], profileIdentifier: ProfileIdentifier? = nil) {
+    public convenience init(locations: [CLLocation], profileIdentifier: ProfileIdentifier? = nil, queryItems: [URLQueryItem]? = nil) {
         let waypoints = locations.map { Waypoint(location: $0) }
-        self.init(waypoints: waypoints, profileIdentifier: profileIdentifier)
+        self.init(waypoints: waypoints, profileIdentifier: profileIdentifier, queryItems: queryItems)
     }
     #endif
 
@@ -44,10 +107,11 @@ open class RouteOptions: DirectionsOptions {
 
      - parameter coordinates: An array of geographic coordinates representing locations that the route should visit in chronological order. The array should contain at least two locations (the source and destination) and at most 25 locations. Each coordinate is converted into a `Waypoint` object.
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. `ProfileIdentifier.automobile` is used by default.
+     - parameter queryItems: URL query items to be parsed and applied as configuration to the resulting options.
      */
-    public convenience init(coordinates: [LocationCoordinate2D], profileIdentifier: ProfileIdentifier? = nil) {
+    public convenience init(coordinates: [LocationCoordinate2D], profileIdentifier: ProfileIdentifier? = nil, queryItems: [URLQueryItem]? = nil) {
         let waypoints = coordinates.map { Waypoint(coordinate: $0) }
-        self.init(waypoints: waypoints, profileIdentifier: profileIdentifier)
+        self.init(waypoints: waypoints, profileIdentifier: profileIdentifier, queryItems: queryItems)
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -320,75 +384,6 @@ open class RouteOptions: DirectionsOptions {
         return params + super.urlQueryItems
     }
     
-    /**
-     Method to deserialize options parameters from given `url`.
-     
-     - parameter url: An URL, used to make a route request.
-     */
-    override open func restore(from url: URL) {
-        super.restore(from: url)
-        
-        guard let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: true)?.queryItems else {
-            return
-        }
-        
-        let mappedQueryItems = Dictionary<String, String>(uniqueKeysWithValues: queryItems.compactMap {
-            guard let value = $0.value else { return nil }
-            return ($0.name, value)
-        })
-        
-        if mappedQueryItems[CodingKeys.includesAlternativeRoutes.stringValue] == "true" {
-            self.includesAlternativeRoutes = true
-        }
-        if mappedQueryItems[CodingKeys.includesExitRoundaboutManeuver.stringValue] == "true" {
-            self.includesExitRoundaboutManeuver = true
-        }
-        if let mappedValue = mappedQueryItems[CodingKeys.alleyPriority.stringValue],
-           let alleyPriority = Double(mappedValue) {
-            self.alleyPriority = DirectionsPriority(rawValue: alleyPriority)
-        }
-        if let mappedValue = mappedQueryItems[CodingKeys.walkwayPriority.stringValue],
-           let walkwayPriority = Double(mappedValue) {
-            self.walkwayPriority = DirectionsPriority(rawValue: walkwayPriority)
-        }
-        if let mappedValue = mappedQueryItems[CodingKeys.speed.stringValue],
-           let speed = LocationSpeed(mappedValue) {
-            self.speed = speed
-        }
-        if let mappedValue = mappedQueryItems[CodingKeys.roadClassesToAvoid.stringValue],
-           let roadClassesToAvoid = RoadClasses(descriptions:mappedValue.components(separatedBy: ",")) {
-            self.roadClassesToAvoid = roadClassesToAvoid
-        }
-        if let mappedValue = mappedQueryItems[CodingKeys.roadClassesToAllow.stringValue],
-           let roadClassesToAllow = RoadClasses(descriptions:mappedValue.components(separatedBy: ",")) {
-            self.roadClassesToAllow = roadClassesToAllow
-        }
-        if mappedQueryItems[CodingKeys.refreshingEnabled.stringValue] == "true" && profileIdentifier == .automobileAvoidingTraffic {
-            self.refreshingEnabled = true
-        }
-        if let mappedValue = mappedQueryItems[CodingKeys.waypointTargets.stringValue] {
-            zip(waypoints.filter { $0.separatesLegs },
-                mappedValue.components(separatedBy: ";")).forEach {
-                let coordinatesComponents = $1.components(separatedBy: ",")
-                if coordinatesComponents.count == 2 {
-                    $0.targetCoordinate = LocationCoordinate2D(latitude: LocationDegrees(coordinatesComponents.last!)!,
-                                                               longitude: LocationDegrees(coordinatesComponents.first!)!)
-                }
-            }
-        }
-        if let mappedValue = mappedQueryItems[CodingKeys.initialManeuverAvoidanceRadius.stringValue],
-           let initialManeuverAvoidanceRadius = LocationDistance(mappedValue) {
-            self.initialManeuverAvoidanceRadius = initialManeuverAvoidanceRadius
-        }
-        if let mappedValue = mappedQueryItems[CodingKeys.maximumHeight.stringValue],
-           let doubleValue = Double(mappedValue) {
-            self.maximumHeight = Measurement(value: doubleValue, unit: UnitLength.meters)
-        }
-        if let mappedValue = mappedQueryItems[CodingKeys.maximumWidth.stringValue],
-           let doubleValue = Double(mappedValue) {
-            self.maximumWidth = Measurement(value: doubleValue, unit: UnitLength.meters)
-        }
-    }
 }
 
 extension LocationSpeed {

--- a/Tests/MapboxDirectionsTests/MatchOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/MatchOptionsTests.swift
@@ -26,6 +26,44 @@ class MatchOptionsTests: XCTestCase {
         XCTAssertEqual(unarchivedOptions.resamplesTraces, options.resamplesTraces)
     }
     
+    func testURLCoding() {
+        
+        let originalOptions = testMatchOptions
+        originalOptions.resamplesTraces = true
+        
+        originalOptions.waypoints.enumerated().forEach {
+            $0.element.separatesLegs = $0.offset != 1
+            if $0.element.separatesLegs {
+                $0.element.name = "name_\($0.offset)"
+                $0.element.targetCoordinate = $0.element.coordinate
+            }
+        }
+        
+        let url = Directions(credentials: BogusCredentials).url(forCalculating: originalOptions)
+        
+        guard let decodedOptions = MatchOptions(url: url) else {
+            XCTFail("Could not decode `MatchOptions`")
+            return
+        }
+        
+        let decodedWaypoints = decodedOptions.waypoints
+        XCTAssertEqual(decodedWaypoints.count, testCoordinates.count)
+        XCTAssertEqual(decodedWaypoints[0].coordinate.latitude, testCoordinates[0].latitude)
+        XCTAssertEqual(decodedWaypoints[0].coordinate.longitude, testCoordinates[0].longitude)
+        XCTAssertEqual(decodedWaypoints[1].coordinate.latitude, testCoordinates[1].latitude)
+        XCTAssertEqual(decodedWaypoints[1].coordinate.longitude, testCoordinates[1].longitude)
+        XCTAssertEqual(decodedWaypoints[2].coordinate.latitude, testCoordinates[2].latitude)
+        XCTAssertEqual(decodedWaypoints[2].coordinate.longitude, testCoordinates[2].longitude)
+        
+        zip(decodedWaypoints, originalOptions.waypoints).forEach {
+            XCTAssertEqual($0.0.separatesLegs, $0.1.separatesLegs)
+            XCTAssertEqual($0.0.name, $0.1.name)
+        }
+        
+        XCTAssertEqual(decodedOptions.profileIdentifier, originalOptions.profileIdentifier)
+        XCTAssertEqual(decodedOptions.resamplesTraces, originalOptions.resamplesTraces)
+    }
+    
     // MARK: API name-handling tests
     
     private static var testTracepoints: [Tracepoint] {

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -117,6 +117,71 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertEqual(unarchivedOptions.maximumHeight, routeOptions.maximumHeight)
     }
     
+    func testURLCoding() {
+        
+        let originalOptions = testRouteOptions
+        originalOptions.includesAlternativeRoutes = true
+        originalOptions.includesExitRoundaboutManeuver = true
+        originalOptions.refreshingEnabled = true
+        
+        originalOptions.waypoints.enumerated().forEach {
+            $0.element.allowsArrivingOnOppositeSide = $0.offset == 2
+            $0.element.coordinateAccuracy = LocationAccuracy($0.offset)
+            $0.element.separatesLegs = $0.offset != 1
+            if $0.element.separatesLegs {
+                $0.element.name = "name_\($0.offset)"
+                $0.element.targetCoordinate = $0.element.coordinate
+            }
+            $0.element.allowsSnappingToClosedRoad = $0.offset == 1
+        }
+        
+        let url = Directions(credentials: BogusCredentials).url(forCalculating: originalOptions)
+        
+        guard let decodedOptions = RouteOptions(url: url) else {
+            XCTFail("Could not decode `RouteOptions`")
+            return
+        }
+        
+        let decodedWaypoints = decodedOptions.waypoints
+        XCTAssertEqual(decodedWaypoints.count, testCoordinates.count)
+        XCTAssertEqual(decodedWaypoints[0].coordinate.latitude, testCoordinates[0].latitude)
+        XCTAssertEqual(decodedWaypoints[0].coordinate.longitude, testCoordinates[0].longitude)
+        XCTAssertEqual(decodedWaypoints[1].coordinate.latitude, testCoordinates[1].latitude)
+        XCTAssertEqual(decodedWaypoints[1].coordinate.longitude, testCoordinates[1].longitude)
+        XCTAssertEqual(decodedWaypoints[2].coordinate.latitude, testCoordinates[2].latitude)
+        XCTAssertEqual(decodedWaypoints[2].coordinate.longitude, testCoordinates[2].longitude)
+        
+        zip(decodedWaypoints, originalOptions.waypoints).forEach {
+            XCTAssertEqual($0.0.allowsSnappingToClosedRoad, $0.1.allowsSnappingToClosedRoad)
+            XCTAssertEqual($0.0.allowsArrivingOnOppositeSide, $0.1.allowsArrivingOnOppositeSide)
+            XCTAssertEqual($0.0.targetCoordinate, $0.1.targetCoordinate)
+            XCTAssertEqual($0.0.separatesLegs, $0.1.separatesLegs)
+            XCTAssertEqual($0.0.coordinateAccuracy, $0.1.coordinateAccuracy)
+            XCTAssertEqual($0.0.name, $0.1.name)
+        }
+        
+        XCTAssertEqual(decodedOptions.includesAlternativeRoutes, originalOptions.includesAlternativeRoutes)
+        XCTAssertEqual(decodedOptions.includesExitRoundaboutManeuver, originalOptions.includesExitRoundaboutManeuver)
+        XCTAssertEqual(decodedOptions.refreshingEnabled, originalOptions.refreshingEnabled)
+        XCTAssertEqual(decodedOptions.shapeFormat, originalOptions.shapeFormat)
+        XCTAssertEqual(decodedOptions.routeShapeResolution, originalOptions.routeShapeResolution)
+        XCTAssertEqual(decodedOptions.includesSteps, originalOptions.includesSteps)
+        XCTAssertEqual(decodedOptions.attributeOptions, originalOptions.attributeOptions)
+        XCTAssertEqual(decodedOptions.profileIdentifier, originalOptions.profileIdentifier)
+        XCTAssertEqual(decodedOptions.locale, originalOptions.locale)
+        XCTAssertEqual(decodedOptions.includesSpokenInstructions, originalOptions.includesSpokenInstructions)
+        XCTAssertEqual(decodedOptions.distanceMeasurementSystem, originalOptions.distanceMeasurementSystem)
+        XCTAssertEqual(decodedOptions.includesVisualInstructions, originalOptions.includesVisualInstructions)
+        XCTAssertEqual(decodedOptions.roadClassesToAvoid, originalOptions.roadClassesToAvoid)
+        XCTAssertEqual(decodedOptions.roadClassesToAllow, originalOptions.roadClassesToAllow)
+        XCTAssertEqual(decodedOptions.initialManeuverAvoidanceRadius, originalOptions.initialManeuverAvoidanceRadius)
+        XCTAssertEqual(decodedOptions.maximumWidth, originalOptions.maximumWidth)
+        XCTAssertEqual(decodedOptions.maximumHeight, originalOptions.maximumHeight)
+        XCTAssertEqual(decodedOptions.alleyPriority, originalOptions.alleyPriority)
+        XCTAssertEqual(decodedOptions.walkwayPriority, originalOptions.walkwayPriority)
+        XCTAssertEqual(decodedOptions.speed, originalOptions.speed)
+    }
+    
     // MARK: API name-handling tests
     
     private static var testWaypoints: [Waypoint] {

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -127,6 +127,8 @@ class RouteOptionsTests: XCTestCase {
         originalOptions.waypoints.enumerated().forEach {
             $0.element.allowsArrivingOnOppositeSide = $0.offset == 2
             $0.element.coordinateAccuracy = LocationAccuracy($0.offset)
+            $0.element.heading = LocationDirection($0.offset * 10)
+            $0.element.headingAccuracy = LocationDirection($0.offset)
             $0.element.separatesLegs = $0.offset != 1
             if $0.element.separatesLegs {
                 $0.element.name = "name_\($0.offset)"
@@ -157,6 +159,8 @@ class RouteOptionsTests: XCTestCase {
             XCTAssertEqual($0.0.targetCoordinate, $0.1.targetCoordinate)
             XCTAssertEqual($0.0.separatesLegs, $0.1.separatesLegs)
             XCTAssertEqual($0.0.coordinateAccuracy, $0.1.coordinateAccuracy)
+            XCTAssertEqual($0.0.heading, $0.1.heading)
+            XCTAssertEqual($0.0.headingAccuracy, $0.1.headingAccuracy)
             XCTAssertEqual($0.0.name, $0.1.name)
         }
         


### PR DESCRIPTION
This PR adds convenience initialization methods to decode `RouteOptions` and `Credentials` from given route request URL. This feature is needed for NavSDK for interacting with NavNative and user code methods which report such entities in string format (in particular, needed for [RerouteController integration](https://github.com/mapbox/mapbox-navigation-ios/pull/3754)).