### PR TITLE
Support multiple road classes in `RouteOptions.roadClassesToAvoid` and `RouteOptions.roadClassesToAllow` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to Mapbox Directions for Swift
 
+## v2.4.0
+
+* Added support for multiple road classes in `RouteOptions.roadClassesToAvoid` and `RouteOptions.roadClassesToAllow` properties. Refer to `RoadClasses` documentation to know which road classes can be avoided or allowed. Trying to avoid a road class that can be only allowed or vice-versa will trigger an assertion failure in Debug builds.
+
 ## v2.3.0
 
 * Added `VisualInstruction.Component.ShieldRepresentation` struct and the `VisualInstruction.Component.ImageRepresentation.shield` property containing metadata for displaying a highway shield consistent with map styles used by the Mapbox Maps SDK. ([#644](https://github.com/mapbox/mapbox-directions-swift/pull/644), [#647](https://github.com/mapbox/mapbox-directions-swift/pull/647))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v2.4.0
 
-* Added support for multiple road classes in `RouteOptions.roadClassesToAvoid` and `RouteOptions.roadClassesToAllow` properties. Refer to `RoadClasses` documentation to know which road classes can be avoided or allowed. Trying to avoid a road class that can be only allowed or vice-versa will trigger an assertion failure in Debug builds.
+* Fixed a crash that occurred when `RouteOptions.roadClassesToAvoid` or `RouteOptions.roadClassesToAllow` properties contained multiple road classes.
+* `RoadClasses.tunnel` and `RoadClasses.restricted` are no longer supported in `RouteOptions.roadClassesToAvoid` or `RouteOptions.roadClassesToAllow` properties
 
 ## v2.3.0
 

--- a/Sources/MapboxDirections/RoadClasses.swift
+++ b/Sources/MapboxDirections/RoadClasses.swift
@@ -185,3 +185,14 @@ extension RoadClasses: Codable {
         }
     }
 }
+
+extension RoadClasses {
+    static var validAvoidClasses: RoadClasses {
+        // .restricted and .tunnel road types are not supported by Directions API anymore
+        return [.toll, .motorway, .ferry, .unpaved, .cashTollOnly]
+    }
+
+    static var validAllowClasses: RoadClasses {
+        return [.highOccupancyVehicle2, .highOccupancyVehicle3, .highOccupancyToll]
+    }
+}

--- a/Sources/MapboxDirections/RoadClasses.swift
+++ b/Sources/MapboxDirections/RoadClasses.swift
@@ -21,6 +21,8 @@ public struct RoadClasses: OptionSet, CustomStringConvertible {
      The road segment has access restrictions.
      
      A road segment may have this class if there are [general access restrictions](https://wiki.openstreetmap.org/wiki/Key:access) or a [high-occupancy vehicle](https://wiki.openstreetmap.org/wiki/Key:hov) restriction.
+
+     This option **cannot** be used with `RouteOptions.roadClassesToAvoid` or `RouteOptions.roadClassesToAllow`.
      */
     public static let restricted = RoadClasses(rawValue: 1 << 2)
     
@@ -46,6 +48,8 @@ public struct RoadClasses: OptionSet, CustomStringConvertible {
     
     /**
      The user must travel this segment of the route through a [tunnel](https://wiki.openstreetmap.org/wiki/Key:tunnel).
+
+     This option **cannot** be used with `RouteOptions.roadClassesToAvoid` or `RouteOptions.roadClassesToAllow`.
      */
     public static let tunnel = RoadClasses(rawValue: 1 << 5)
     
@@ -184,7 +188,6 @@ extension RoadClasses: Codable {
 
 extension RoadClasses {
     static var validAvoidClasses: RoadClasses {
-        // .restricted and .tunnel road types are not supported by Directions API anymore
         return [.toll, .motorway, .ferry, .unpaved, .cashTollOnly]
     }
 

--- a/Sources/MapboxDirections/RoadClasses.swift
+++ b/Sources/MapboxDirections/RoadClasses.swift
@@ -185,13 +185,3 @@ extension RoadClasses: Codable {
         }
     }
 }
-
-extension RoadClasses {
-    static var validAvoidClasses: RoadClasses {
-        return [.toll, .motorway, .ferry, .unpaved, .cashTollOnly]
-    }
-
-    static var validAllowClasses: RoadClasses {
-        return [.highOccupancyVehicle2, .highOccupancyVehicle3, .highOccupancyToll]
-    }
-}

--- a/Sources/MapboxDirections/RoadClasses.swift
+++ b/Sources/MapboxDirections/RoadClasses.swift
@@ -21,8 +21,6 @@ public struct RoadClasses: OptionSet, CustomStringConvertible {
      The road segment has access restrictions.
      
      A road segment may have this class if there are [general access restrictions](https://wiki.openstreetmap.org/wiki/Key:access) or a [high-occupancy vehicle](https://wiki.openstreetmap.org/wiki/Key:hov) restriction.
-     
-     This option can only be used with `RouteOptions.roadClassesToAvoid`.
      */
     public static let restricted = RoadClasses(rawValue: 1 << 2)
     
@@ -48,8 +46,6 @@ public struct RoadClasses: OptionSet, CustomStringConvertible {
     
     /**
      The user must travel this segment of the route through a [tunnel](https://wiki.openstreetmap.org/wiki/Key:tunnel).
-     
-     This option can only be used with `RouteOptions.roadClassesToAvoid`.
      */
     public static let tunnel = RoadClasses(rawValue: 1 << 5)
     

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -283,18 +283,12 @@ open class RouteOptions: DirectionsOptions {
         }
 
         if !roadClassesToAvoid.isEmpty {
-            if !roadClassesToAvoid.isSubset(of: .validAvoidClasses) {
-                assertionFailure("Provided road classes cannot be avoided")
-            }
-            let roadClasses = roadClassesToAvoid.intersection(.validAvoidClasses).description
+            let roadClasses = roadClassesToAvoid.description
             params.append(URLQueryItem(name: CodingKeys.roadClassesToAvoid.stringValue, value: roadClasses))
         }
         
         if !roadClassesToAllow.isEmpty {
-            if !roadClassesToAllow.isSubset(of: .validAllowClasses) {
-                assertionFailure("Provided road classes cannot be included")
-            }
-            let parameterValue = roadClassesToAllow.intersection(.validAllowClasses).description
+            let parameterValue = roadClassesToAllow.description
             params.append(URLQueryItem(name: CodingKeys.roadClassesToAllow.stringValue, value: parameterValue))
         }
         

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -281,20 +281,21 @@ open class RouteOptions: DirectionsOptions {
         if let speed = speed {
             params.append(URLQueryItem(name: CodingKeys.speed.stringValue, value: String(speed)))
         }
-        
-        if !roadClassesToAvoid.isEmpty && roadClassesToAvoid.isDisjoint(with: [.highOccupancyVehicle2, .highOccupancyVehicle3, .highOccupancyToll]) {
-            let allRoadClasses = roadClassesToAvoid.description.components(separatedBy: ",").filter { !$0.isEmpty }
-            precondition(allRoadClasses.count < 2, "You can only avoid one road class at a time.")
-            if let firstRoadClass = allRoadClasses.first {
-                params.append(URLQueryItem(name: CodingKeys.roadClassesToAvoid.stringValue, value: firstRoadClass))
+
+        if !roadClassesToAvoid.isEmpty {
+            if !roadClassesToAvoid.isSubset(of: .validAvoidClasses) {
+                assertionFailure("Provided road classes cannot be avoided")
             }
+            let roadClasses = roadClassesToAvoid.intersection(.validAvoidClasses).description
+            params.append(URLQueryItem(name: CodingKeys.roadClassesToAvoid.stringValue, value: roadClasses))
         }
         
-        if !roadClassesToAllow.isEmpty && roadClassesToAllow.isSubset(of: [.highOccupancyVehicle2, .highOccupancyVehicle3, .highOccupancyToll]) {
-            let allRoadClasses = roadClassesToAllow.description.components(separatedBy: ",").filter { !$0.isEmpty }
-            allRoadClasses.forEach { roadClass in
-                params.append(URLQueryItem(name: CodingKeys.roadClassesToAllow.stringValue, value: roadClass))
+        if !roadClassesToAllow.isEmpty {
+            if !roadClassesToAllow.isSubset(of: .validAllowClasses) {
+                assertionFailure("Provided road classes cannot be included")
             }
+            let parameterValue = roadClassesToAllow.intersection(.validAllowClasses).description
+            params.append(URLQueryItem(name: CodingKeys.roadClassesToAllow.stringValue, value: parameterValue))
         }
         
         if refreshingEnabled && profileIdentifier == .automobileAvoidingTraffic {

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -250,8 +250,8 @@ class RouteOptionsTests: XCTestCase {
 
     func testExcludeAndIncludeRoadClasses() {
         let options = RouteOptions(coordinates: [])
-        options.roadClassesToAvoid = .validAvoidClasses
-        options.roadClassesToAllow = .validAllowClasses
+        options.roadClassesToAvoid = [.toll, .motorway, .ferry, .unpaved, .cashTollOnly]
+        options.roadClassesToAllow = [.highOccupancyVehicle2, .highOccupancyVehicle3, .highOccupancyToll]
 
         let expectedExcludeQueryItem = URLQueryItem(name: "exclude", value: "toll,motorway,ferry,unpaved,cash_only_toll")
         XCTAssertTrue(options.urlQueryItems.contains(expectedExcludeQueryItem))

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -247,6 +247,18 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertTrue(options.urlQueryItems.contains(URLQueryItem(name: "max_width", value: String(widthValue))))
         XCTAssertTrue(options.urlQueryItems.contains(URLQueryItem(name: "max_height", value: String(heightValue))))
     }
+
+    func testExcludeAndIncludeRoadClasses() {
+        let options = RouteOptions(coordinates: [])
+        options.roadClassesToAvoid = .validAvoidClasses
+        options.roadClassesToAllow = .validAllowClasses
+
+        let expectedExcludeQueryItem = URLQueryItem(name: "exclude", value: "toll,motorway,ferry,unpaved,cash_only_toll")
+        XCTAssertTrue(options.urlQueryItems.contains(expectedExcludeQueryItem))
+
+        let expectedIncludeQueryItem = URLQueryItem(name: "include", value: "hov2,hov3,hot")
+        XCTAssertTrue(options.urlQueryItems.contains(expectedIncludeQueryItem))
+    }
 }
 
 fileprivate let testCoordinates = [


### PR DESCRIPTION
[Directions server-side API](https://docs.mapbox.com/api/navigation/directions/) now allows passing multiple road classes in these fields, so the corresponding SDK code is updated.

Looks like `RoadClasses.tunnel` and `RoadClasses.restricted` are not supported by Directions API in `RouteOptions.roadClassesToAvoid` anymore, so I updated documentation for these properties.

Error when trying to avoid tunnels:
<img width="911" alt="image" src="https://user-images.githubusercontent.com/1976216/158222625-fbe0864c-8b5c-4ecc-8bc3-22846c17cc9a.png">


@1ec5 Looks like `RoadClasses.tunnel` and `RoadClasses.restricted` were only used in `RouteOptions.roadClassesToAvoid `, now that Directions API doesn't support them, should we mark these properties as deprecated?