### PR TITLE
Exposing `departAt` and `arriveBy` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `RoadClasses.tunnel` and `RoadClasses.restricted` are no longer supported in `RouteOptions.roadClassesToAvoid` or `RouteOptions.roadClassesToAllow` properties
 * Added `DirectionsOptions(url:)`, `RouteOptions(url:)` and extended existing `DirectionsOptions(waypoints:profileIdentifier:queryItems:)`, `RouteOptions(waypoints:profileIdentifier:queryItems:)`, `MatchOptions(waypoints:profileIdentifier:queryItems:)` and related convenience init methods for deserializing corresponding options object using appropriate request URL or it's query items. ([#655](https://github.com/mapbox/mapbox-directions-swift/pull/655))
 * Added `Incident` properties: `countryCode`, `countryCodeAlpha3`, `roadIsClosed`, `longDescription`, `numberOfBlockedLanes`, `congestionLevel`, `affectedRoadNames`. ([#672](https://github.com/mapbox/mapbox-directions-swift/pull/672))
+* Added `departAt` and `arriveBy` properties to `RouteOptions` to allow configuring Directions routes calculation. ([#673](https://github.com/mapbox/mapbox-directions-swift/pull/673))
 
 ## v2.3.0
 

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -184,6 +184,8 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertEqual(decodedOptions.alleyPriority, originalOptions.alleyPriority)
         XCTAssertEqual(decodedOptions.walkwayPriority, originalOptions.walkwayPriority)
         XCTAssertEqual(decodedOptions.speed, originalOptions.speed)
+        XCTAssertNil(decodedOptions.arriveBy)
+        XCTAssertEqual(decodedOptions.departAt, originalOptions.departAt)
     }
     
     // MARK: API name-handling tests
@@ -355,6 +357,8 @@ var testRouteOptions: RouteOptions {
     opts.alleyPriority = .low
     opts.walkwayPriority = .high
     opts.speed = 1
+    opts.departAt = Date(timeIntervalSince1970: 500)
+    opts.arriveBy = Date(timeIntervalSince1970: 600)
 
     return opts
 }

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -185,7 +185,8 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertEqual(decodedOptions.walkwayPriority, originalOptions.walkwayPriority)
         XCTAssertEqual(decodedOptions.speed, originalOptions.speed)
         XCTAssertNil(decodedOptions.arriveBy)
-        XCTAssertEqual(decodedOptions.departAt, originalOptions.departAt)
+        // URL encoding skips seconds, so we check that dates are within 1 minute delta
+        XCTAssertTrue(abs(decodedOptions.departAt!.timeIntervalSince(originalOptions.departAt!)) < 60)
     }
     
     // MARK: API name-handling tests


### PR DESCRIPTION
This PR adds support for route options `departAt` and `arriveBy`. Changes include JSON coding and URL conversion.

[Docs](https://docs.mapbox.com/api/navigation/directions/#optional-parameters-for-the-mapboxdriving-profile) say that both parameters should be ISO8601 formatted, but in fact it requires no seconds to be specified by error:
```Time must be a valid timestamp in the format YYYY-MM-DDTHH:mm```