### PR TITLE
V5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added `DirectionsOptions(url:)`, `RouteOptions(url:)` and extended existing `DirectionsOptions(waypoints:profileIdentifier:queryItems:)`, `RouteOptions(waypoints:profileIdentifier:queryItems:)`, `MatchOptions(waypoints:profileIdentifier:queryItems:)` and related convenience init methods for deserializing corresponding options object using appropriate request URL or it's query items. ([#655](https://github.com/mapbox/mapbox-directions-swift/pull/655))
 * Added `Incident` properties: `countryCode`, `countryCodeAlpha3`, `roadIsClosed`, `longDescription`, `numberOfBlockedLanes`, `congestionLevel`, `affectedRoadNames`. ([#672](https://github.com/mapbox/mapbox-directions-swift/pull/672))
 * Added `departAt` and `arriveBy` properties to `RouteOptions` to allow configuring Directions routes calculation. ([#673](https://github.com/mapbox/mapbox-directions-swift/pull/673))
+* Removed url request's `.json` suffix for Directions and Isochrones to follow V5 scheme. ()
 
 ## v2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Added `DirectionsOptions(url:)`, `RouteOptions(url:)` and extended existing `DirectionsOptions(waypoints:profileIdentifier:queryItems:)`, `RouteOptions(waypoints:profileIdentifier:queryItems:)`, `MatchOptions(waypoints:profileIdentifier:queryItems:)` and related convenience init methods for deserializing corresponding options object using appropriate request URL or it's query items. ([#655](https://github.com/mapbox/mapbox-directions-swift/pull/655))
 * Added `Incident` properties: `countryCode`, `countryCodeAlpha3`, `roadIsClosed`, `longDescription`, `numberOfBlockedLanes`, `congestionLevel`, `affectedRoadNames`. ([#672](https://github.com/mapbox/mapbox-directions-swift/pull/672))
 * Added `departAt` and `arriveBy` properties to `RouteOptions` to allow configuring Directions routes calculation. ([#673](https://github.com/mapbox/mapbox-directions-swift/pull/673))
-* Removed url request's `.json` suffix for Directions and Isochrones to follow V5 scheme. ()
+* Removed url request's `.json` suffix for Directions and Isochrones to follow V5 scheme. ([#678](https://github.com/mapbox/mapbox-directions-swift/pull/678))
 
 ## v2.3.0
 

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -435,7 +435,7 @@ open class DirectionsOptions: Codable {
             assertionFailure("No query")
             return ""
         }
-        return "\(abridgedPath)/\(coordinates).json"
+        return "\(abridgedPath)/\(coordinates)"
     }
     
     /**

--- a/Sources/MapboxDirections/IsochroneOptions.swift
+++ b/Sources/MapboxDirections/IsochroneOptions.swift
@@ -86,7 +86,7 @@ public class IsochroneOptions {
      The path of the request URL, not including the hostname or any parameters.
      */
     var path: String {
-        return "\(abridgedPath)/\(centerCoordinate.requestDescription).json"
+        return "\(abridgedPath)/\(centerCoordinate.requestDescription)"
     }
     
     /**

--- a/Tests/MapboxDirectionsTests/MatchTests.swift
+++ b/Tests/MapboxDirectionsTests/MatchTests.swift
@@ -167,7 +167,7 @@ class MatchTests: XCTestCase {
     #endif
     
     func testCoding() {
-        // https://api.mapbox.com/matching/v5/mapbox/driving/-84.51200,39.09740;-84.51118,39.09638;-84.51021,39.09687.json?geometries=polyline&overview=false&tidy=false&access_token=…
+        // https://api.mapbox.com/matching/v5/mapbox/driving/-84.51200,39.09740;-84.51118,39.09638;-84.51021,39.09687?geometries=polyline&overview=false&tidy=false&access_token=…
         let matchJSON: [String: Any?] = [
             "confidence": 0.00007401405321383336,
             "legs": [

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -228,13 +228,13 @@ class RouteOptionsTests: XCTestCase {
     }
     
     func testResponseWithoutDestinationName() {
-        // https://api.mapbox.com/directions/v5/mapbox/driving/-84.411389,39.27665;-84.412115,39.272675.json?overview=false&steps=false&access_token=pk.feedcafedeadbeef
+        // https://api.mapbox.com/directions/v5/mapbox/driving/-84.411389,39.27665;-84.412115,39.272675?overview=false&steps=false&access_token=pk.feedcafedeadbeef
         let response = self.response(for: "noDestinationName")!
         XCTAssertNil(response.route.legs.last?.destination?.name, "Empty-string waypoint name in API responds should be represented as nil.")
     }
     
     func testResponseWithDestinationName() {
-        // https://api.mapbox.com/directions/v5/mapbox/driving/-84.411389,39.27665;-84.41195,39.27260.json?overview=false&steps=false&access_token=pk.feedcafedeadbeef
+        // https://api.mapbox.com/directions/v5/mapbox/driving/-84.411389,39.27665;-84.41195,39.27260?overview=false&steps=false&access_token=pk.feedcafedeadbeef
         let response = self.response(for: "apiDestinationName")!
         XCTAssertEqual(response.route.legs.last?.destination?.name, "Reading Road", "Waypoint name in fixture response not parsed correctly.")
     }

--- a/Tests/MapboxDirectionsTests/RouteStepTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteStepTests.swift
@@ -97,7 +97,7 @@ class RoadTests: XCTestCase {
 
 class RouteStepTests: XCTestCase {
     func testDecoding() {
-        // Derived from <https://api.mapbox.com/directions/v5/mapbox/driving-traffic/-122.22060192394258,37.853964632136226;-122.22001854348318,37.85415735273948.json?geometries=polyline&steps=true&overview=full&access_token=pk.feedcafedeadbeef>
+        // Derived from <https://api.mapbox.com/directions/v5/mapbox/driving-traffic/-122.22060192394258,37.853964632136226;-122.22001854348318,37.85415735273948?geometries=polyline&steps=true&overview=full&access_token=pk.feedcafedeadbeef>
         let stepJSON = [
             "driving_side": "right",
             "geometry": "ek`fFxc~hVIu@",

--- a/Tests/MapboxDirectionsTests/RouteTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteTests.swift
@@ -5,7 +5,7 @@ import Turf
 
 class RouteTests: XCTestCase {
     func testCoding() {
-        // https://api.mapbox.com/directions/v5/mapbox/driving-traffic/-105.08198579860195%2C39.73843005470756;-104.954255,39.662569.json?overview=false&access_token=…
+        // https://api.mapbox.com/directions/v5/mapbox/driving-traffic/-105.08198579860195%2C39.73843005470756;-104.954255,39.662569?overview=false&access_token=…
         let routeJSON: [String: Any?] = [
             "legs": [
                 [
@@ -87,7 +87,7 @@ class RouteTests: XCTestCase {
         // Key arguments:
         // - voice_instructions=true - makes the API to include "voiceLocale" in the response
         // - language=he - one of the unsupported languages by the API, which makes API to return `nil` for "voiceLocale"
-        // https://api.mapbox.com/directions/v5/mapbox/driving-traffic/-105.081986,39.73843;-104.954255,39.662569.json?overview=false&language=he&voice_instructions=true&access_token=...
+        // https://api.mapbox.com/directions/v5/mapbox/driving-traffic/-105.081986,39.73843;-104.954255,39.662569?overview=false&language=he&voice_instructions=true&access_token=...
 
         let routeJSON: [String: Any?] = [
             "legs": [

--- a/Tests/MapboxDirectionsTests/V5Tests.swift
+++ b/Tests/MapboxDirectionsTests/V5Tests.swift
@@ -27,7 +27,7 @@ class V5Tests: XCTestCase {
             "access_token": BogusToken,
         ]
         stub(condition: isHost("api.mapbox.com")
-            && isPath("/directions/v5/mapbox/driving/-122.42,37.78;-77.03,38.91.json")
+            && isPath("/directions/v5/mapbox/driving/-122.42,37.78;-77.03,38.91")
             && containsQueryParams(queryParams)) { _ in
                 let path = Bundle.module.path(forResource: filePath ?? "v5_driving_dc_\(shapeFormat.rawValue)", ofType: "json")
                 let filePath = URL(fileURLWithPath: path!)
@@ -222,7 +222,7 @@ class V5Tests: XCTestCase {
             "access_token": BogusToken,
         ]
         stub(condition: isHost("api.mapbox.com")
-            && isPath("/directions/v5/mapbox/driving/-85.206232,39.33841;-85.203991,39.34181;-85.199697,39.342048.json")
+            && isPath("/directions/v5/mapbox/driving/-85.206232,39.33841;-85.203991,39.34181;-85.199697,39.342048")
             && containsQueryParams(queryParams)) { _ in
                 let path = Bundle.module.path(forResource: "v5_driving_oldenburg_polyline", ofType: "json")
                 let filePath = URL(fileURLWithPath: path!)


### PR DESCRIPTION
This PR removes obsolete `.json` extension from Directions and Isochrones requests to match v5 scheme.