### PR TITLE
Provide convenience initializers for options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes to Mapbox Directions for Swift
 
+## v2.4.1
+* Fixed an issue that caused a compiler error when subclassing `RouteOptions`. ([#685](https://github.com/mapbox/mapbox-directions-swift/pull/685))
+
 ## v2.4.0
 
 * Fixed a crash that occurred when `RouteOptions.roadClassesToAvoid` or `RouteOptions.roadClassesToAllow` properties contained multiple road classes.

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -219,6 +219,18 @@ open class DirectionsOptions: Codable {
     }
     
     /**
+     Initializes an options object for routes between the given waypoints and an optional profile identifier.
+
+     Do not call `DirectionsOptions(waypoints:profileIdentifier:)` directly; instead call the corresponding initializer of `RouteOptions` or `MatchOptions`.
+
+     - parameter waypoints: An array of `Waypoint` objects representing locations that the route should visit in chronological order. The array should contain at least two waypoints (the source and destination) and at most 25 waypoints. (Some profiles, such as `ProfileIdentifier.automobileAvoidingTraffic`, [may have lower limits](https://docs.mapbox.com/api/navigation/#directions).)
+     - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. `ProfileIdentifier.automobile` is used by default.
+     */
+    public convenience init(waypoints: [Waypoint], profileIdentifier: ProfileIdentifier? = nil) {
+        self.init(waypoints: waypoints, profileIdentifier: profileIdentifier, queryItems: nil)
+    }
+    
+    /**
      Creates new options object by deserializing given `url`
      
      Initialization fails if it is unable to extract `waypoints` list and `profileIdentifier`. If other properties are failed to decode - it will just skip them.

--- a/Sources/MapboxDirections/MapMatching/MatchOptions.swift
+++ b/Sources/MapboxDirections/MapMatching/MatchOptions.swift
@@ -42,6 +42,16 @@ open class MatchOptions: DirectionsOptions {
         self.init(waypoints: waypoints, profileIdentifier: profileIdentifier, queryItems: queryItems)
     }
 
+    /**
+     Initializes a match options object for matching locations against the road network.
+
+     - parameter waypoints: An array of `Waypoint` objects representing locations that the route should visit in chronological order. The array should contain at least two waypoints (the source and destination) and at most 25 waypoints. (Some profiles, such as `ProfileIdentifier.automobileAvoidingTraffic`, [may have lower limits](https://docs.mapbox.com/api/navigation/#directions).)
+     - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. `ProfileIdentifier.automobile` is used by default.
+     */
+    public convenience init(waypoints: [Waypoint], profileIdentifier: ProfileIdentifier? = nil) {
+        self.init(waypoints: waypoints, profileIdentifier: profileIdentifier, queryItems: nil)
+    }
+    
     public required init(waypoints: [Waypoint], profileIdentifier: ProfileIdentifier? = nil, queryItems: [URLQueryItem]? = nil) {
         super.init(waypoints: waypoints, profileIdentifier: profileIdentifier, queryItems: queryItems)
         

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -98,6 +98,16 @@ open class RouteOptions: DirectionsOptions {
             self.arriveBy = arriveBy
         }
     }
+    
+    /**
+     Initializes a route options object for routes between the given waypoints and an optional profile identifier.
+
+     - parameter waypoints: An array of `Waypoint` objects representing locations that the route should visit in chronological order. The array should contain at least two waypoints (the source and destination) and at most 25 waypoints. (Some profiles, such as `ProfileIdentifier.automobileAvoidingTraffic`, [may have lower limits](https://www.mapbox.com/api-documentation/#directions).)
+     - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. `ProfileIdentifier.automobile` is used by default.
+     */
+    public convenience init(waypoints: [Waypoint], profileIdentifier: ProfileIdentifier? = nil) {
+        self.init(waypoints: waypoints, profileIdentifier: profileIdentifier, queryItems: nil)
+    }
 
     #if canImport(CoreLocation)
     /**

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -363,3 +363,11 @@ var testRouteOptions: RouteOptions {
 
     return opts
 }
+
+var routeOptionsSubclassTest = testRouteOptionsSubclass(waypoints: [])
+
+class testRouteOptionsSubclass: RouteOptions {
+    convenience init(waypoints: [Waypoint], profileIdentifier: ProfileIdentifier?) {
+        self.init(waypoints: [], profileIdentifier: nil, queryItems: nil)
+    }
+}


### PR DESCRIPTION
This PR fixes #684 by adding convenience initializers for `RouteOptions`, `MatchOptions`, and `DirectionsOptions`.