### PR TITLE
Fix crash that occurs when directions are requested without waypoints

### DIFF
--- a/Sources/MapboxDirections/Directions.swift
+++ b/Sources/MapboxDirections/Directions.swift
@@ -521,7 +521,6 @@ open class Directions: NSObject {
      - returns: The URL to send the request to.
      */
     open func url(forCalculating options: DirectionsOptions) -> URL {
-        if options.waypoints.count < 2 { assertionFailure("waypoints array requires at least 2 waypoints") }
         return url(forCalculating: options, httpMethod: "GET")
     }
     

--- a/Sources/MapboxDirections/Directions.swift
+++ b/Sources/MapboxDirections/Directions.swift
@@ -521,6 +521,7 @@ open class Directions: NSObject {
      - returns: The URL to send the request to.
      */
     open func url(forCalculating options: DirectionsOptions) -> URL {
+        if options.waypoints.count < 2 { assertionFailure("waypoints array requires at least 2 waypoints") }
         return url(forCalculating: options, httpMethod: "GET")
     }
     
@@ -536,8 +537,6 @@ open class Directions: NSObject {
      - returns: The URL to send the request to.
      */
     open func url(forCalculating options: DirectionsOptions, httpMethod: String) -> URL {
-        if options.waypoints.count < 2 { assertionFailure("waypoints array requires at least 2 waypoints") }
-
         let includesQuery = httpMethod != "POST"
         var params = (includesQuery ? options.urlQueryItems : [])
         params.append(contentsOf: authenticationParams)
@@ -559,6 +558,7 @@ open class Directions: NSObject {
      - returns: A GET or POST HTTP request to calculate the specified options.
      */
     open func urlRequest(forCalculating options: DirectionsOptions) -> URLRequest {
+        if options.waypoints.count < 2 { assertionFailure("waypoints array requires at least 2 waypoints") }
         let getURL = self.url(forCalculating: options, httpMethod: "GET")
         var request = URLRequest(url: getURL)
         if getURL.absoluteString.count > MaximumURLLength {

--- a/Sources/MapboxDirections/Directions.swift
+++ b/Sources/MapboxDirections/Directions.swift
@@ -536,6 +536,8 @@ open class Directions: NSObject {
      - returns: The URL to send the request to.
      */
     open func url(forCalculating options: DirectionsOptions, httpMethod: String) -> URL {
+        if options.waypoints.count < 2 { assertionFailure("waypoints array requires at least 2 waypoints") }
+
         let includesQuery = httpMethod != "POST"
         var params = (includesQuery ? options.urlQueryItems : [])
         params.append(contentsOf: authenticationParams)

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -129,8 +129,6 @@ open class DirectionsOptions: Codable {
         self.waypoints = waypoints
         self.profileIdentifier = profileIdentifier ?? .automobile
         
-        if waypoints.count < 2 { assertionFailure("waypoints array requires at least 2 waypoints") }
-        
         guard let queryItems = queryItems else {
             return
         }

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -436,7 +436,7 @@ open class DirectionsOptions: Codable {
             return ""
         }
         
-        if coordinates.count < 2 {
+        if waypoints.count < 2 {
             return "\(abridgedPath)"
         }
         

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -129,6 +129,8 @@ open class DirectionsOptions: Codable {
         self.waypoints = waypoints
         self.profileIdentifier = profileIdentifier ?? .automobile
         
+        if waypoints.count < 2 { assertionFailure("waypoints array requires at least 2 waypoints") }
+        
         guard let queryItems = queryItems else {
             return
         }

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -431,10 +431,15 @@ open class DirectionsOptions: Codable {
      The path of the request URL, not including the hostname or any parameters.
      */
     var path: String {
-        guard let coordinates = coordinates, !coordinates.isEmpty else {
+        guard let coordinates = coordinates else {
             assertionFailure("No query")
             return ""
         }
+        
+        if coordinates.count < 2 {
+            return "\(abridgedPath)"
+        }
+        
         return "\(abridgedPath)/\(coordinates)"
     }
     

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -331,6 +331,13 @@ class RouteOptionsTests: XCTestCase {
         let expectedIncludeQueryItem = URLQueryItem(name: "include", value: "hov2,hov3,hot")
         XCTAssertTrue(options.urlQueryItems.contains(expectedIncludeQueryItem))
     }
+    
+    func testNoWaypointsAndOneWaypoint() {
+        let noWaypointOptions = RouteOptions(coordinates: [])
+        XCTAssertEqual(noWaypointOptions.path, noWaypointOptions.abridgedPath)
+        let oneWaypointOptions = RouteOptions(coordinates: [LocationCoordinate2D(latitude: 0.0, longitude: 0.0)])
+        XCTAssertEqual(oneWaypointOptions.path, oneWaypointOptions.abridgedPath)
+    }
 }
 
 fileprivate let testCoordinates = [

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -299,7 +299,7 @@ class RouteOptionsTests: XCTestCase {
     }
     
     func testInitialManeuverAvoidanceRadiusSerialization() {
-        let options = RouteOptions(coordinates: [])
+        let options = RouteOptions(coordinates: testCoordinates)
         
         options.initialManeuverAvoidanceRadius = 123.456
         
@@ -311,7 +311,7 @@ class RouteOptionsTests: XCTestCase {
     }
 
     func testMaximumWidthAndMaximimHeightSerialization() {
-        let options = RouteOptions(coordinates: [])
+        let options = RouteOptions(coordinates: testCoordinates)
         let widthValue = 2.3
         let heightValue = 2.0
         options.maximumWidth = Measurement(value: widthValue, unit: .meters)
@@ -321,7 +321,7 @@ class RouteOptionsTests: XCTestCase {
     }
 
     func testExcludeAndIncludeRoadClasses() {
-        let options = RouteOptions(coordinates: [])
+        let options = RouteOptions(coordinates: testCoordinates)
         options.roadClassesToAvoid = [.toll, .motorway, .ferry, .unpaved, .cashTollOnly]
         options.roadClassesToAllow = [.highOccupancyVehicle2, .highOccupancyVehicle3, .highOccupancyToll]
 

--- a/Tests/MapboxDirectionsTests/RouteResponseTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteResponseTests.swift
@@ -6,7 +6,7 @@ class RouteResponseTests: XCTestCase {
     
     func testRouteResponseEncodingAndDecoding() {
         let originCoordinate = LocationCoordinate2D(latitude: 39.15031, longitude: -84.47182)
-        let originWaypoint = Waypoint(coordinate: originCoordinate, name: "Test waypoint")
+        let originWaypoint = Waypoint(coordinate: originCoordinate, name: "Test origin waypoint")
         originWaypoint.targetCoordinate = originCoordinate
         originWaypoint.coordinateAccuracy = 1.0
         originWaypoint.heading = 120.0
@@ -14,7 +14,10 @@ class RouteResponseTests: XCTestCase {
         originWaypoint.separatesLegs = false
         originWaypoint.allowsArrivingOnOppositeSide = false
         
-        let waypoints = [originWaypoint]
+        let destinationCoordinate = LocationCoordinate2D(latitude: 39.15031, longitude: -84.47865)
+        let destinationWaypoint = Waypoint(coordinate: destinationCoordinate, name: "Test destination waypoint")
+        
+        let waypoints = [originWaypoint, destinationWaypoint]
         let routeOptions = RouteOptions(waypoints: waypoints)
         let responseOptions = ResponseOptions.route(routeOptions)
         


### PR DESCRIPTION
This PR fixes #515 by including an assertion failure when any options (`DirectionsOptions` and its affiliated subclasses) are initialized with less than 2 waypoints or coordinates. Some tests that initialize `RouteOptions` with less than 2 waypoints in the Nav SDK will need to be updated.