### PR TITLE
Add RestStop.name; fix macOS builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to Mapbox Directions for Swift
 
+## v2.5.0
+
+* Added the `RestStop.name` property. ([#689](https://github.com/mapbox/mapbox-directions-swift/pull/689))
+
 ## v2.4.0
 
 * Fixed a crash that occurred when `RouteOptions.roadClassesToAvoid` or `RouteOptions.roadClassesToAllow` properties contained multiple road classes.

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "9.1.0"
 github "mapbox/mapbox-events-ios" "v0.10.14"
-github "mapbox/turf-swift" "v2.2.0"
-github "raphaelmor/Polyline" "v5.0.2"
+github "mapbox/turf-swift" "v2.4.0"
+github "raphaelmor/Polyline" "v5.0.3"

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/raphaelmor/Polyline.git",
         "state": {
           "branch": null,
-          "revision": "36f7b1222aaf8fa741d0d179c12e186998d97f42",
-          "version": "5.0.2"
+          "revision": "554a15b15ff33cf6757f4cb693c5c285fe58694e",
+          "version": "5.0.3"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "e1465042f195f374b94f915ba8ca49de24300a0d",
-          "version": "1.0.2"
+          "revision": "f3c9084a71ef4376f2fabbdf1d3d90a49f1fabdb",
+          "version": "1.1.2"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "436682278bd65a1dbfbad53902af6f4cc0af1a33",
-          "version": "2.2.0"
+          "revision": "569e0f0e96fda86e1a1dcefaefa68cfa9491ffc1",
+          "version": "2.4.0"
         }
       }
     ]

--- a/Sources/MapboxDirections/RestStop.swift
+++ b/Sources/MapboxDirections/RestStop.swift
@@ -1,12 +1,14 @@
 import Foundation
 
 /**
- `RestStop` describes corresponding object on the route.
+ A [rest stop](https://wiki.openstreetmap.org/wiki/Tag:highway%3Drest_area) along the route.
  */
 public struct RestStop: Codable, Equatable {
-
+    /// A kind of rest stop.
     public enum StopType: String, Codable {
+        /// A primitive rest stop that provides parking but no additional services.
         case serviceArea = "service_area"
+        /// A major rest stop that provides amenities such as fuel and food.
         case restArea = "rest_area"
     }
 
@@ -14,12 +16,23 @@ public struct RestStop: Codable, Equatable {
      The kind of the rest stop.
      */
     public let type: StopType
+    
+    /// The name of the rest stop, if available.
+    public let name: String?
 
     private enum CodingKeys: String, CodingKey {
         case type
+        case name
     }
     
-    public init(type: StopType) {
+    /**
+     Initializes a rest stop with the given kind and name.
+     
+     - parameter type: The kind of rest stop.
+     - parameter name: The name of the rest stop.
+     */
+    public init(type: StopType, name: String? = nil) {
         self.type = type
+        self.name = name
     }
 }

--- a/Sources/MapboxDirections/RestStop.swift
+++ b/Sources/MapboxDirections/RestStop.swift
@@ -26,12 +26,22 @@ public struct RestStop: Codable, Equatable {
     }
     
     /**
-     Initializes a rest stop with the given kind and name.
+     Initializes an unnamed rest stop of a certain kind.
+     
+     - parameter type: The kind of rest stop.
+     */
+    public init(type: StopType) {
+        self.type = type
+        self.name = nil
+    }
+    
+    /**
+     Initializes an optionally named rest stop of a certain kind.
      
      - parameter type: The kind of rest stop.
      - parameter name: The name of the rest stop.
      */
-    public init(type: StopType, name: String? = nil) {
+    public init(type: StopType, name: String?) {
         self.type = type
         self.name = name
     }

--- a/Tests/MapboxDirectionsTests/AnnotationTests.swift
+++ b/Tests/MapboxDirectionsTests/AnnotationTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 #if !os(Linux)
+import CoreLocation
 #if SWIFT_PACKAGE
 import OHHTTPStubsSwift
 #endif

--- a/Tests/MapboxDirectionsTests/OfflineDirectionsTests.swift
+++ b/Tests/MapboxDirectionsTests/OfflineDirectionsTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 #if !os(Linux)
+import CoreLocation
 import OHHTTPStubs
 #if SWIFT_PACKAGE
 import OHHTTPStubsSwift

--- a/Tests/MapboxDirectionsTests/RoutableMatchTests.swift
+++ b/Tests/MapboxDirectionsTests/RoutableMatchTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 #if !os(Linux)
+import CoreLocation
 import OHHTTPStubs
 #if SWIFT_PACKAGE
 import OHHTTPStubsSwift

--- a/Tests/MapboxDirectionsTests/V5Tests.swift
+++ b/Tests/MapboxDirectionsTests/V5Tests.swift
@@ -1,5 +1,6 @@
 import XCTest
 #if !os(Linux)
+import CoreLocation
 import OHHTTPStubs
 #if SWIFT_PACKAGE
 import OHHTTPStubsSwift

--- a/Tests/MapboxDirectionsTests/VisualInstructionTests.swift
+++ b/Tests/MapboxDirectionsTests/VisualInstructionTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 #if !os(Linux)
+import CoreLocation
 import OHHTTPStubs
 #if SWIFT_PACKAGE
 import OHHTTPStubsSwift


### PR DESCRIPTION
The Mapbox Directions API has long had a [`rest_stop.name`](https://docs.mapbox.com/api/navigation/directions/#route-step-object) property in the response model, indicating the name of the rest area or service area. In response, this PR adds a `RestStop.name` property.

Along for the ride, this PR adds several Core Location import statements to the tests so they build on macOS in Xcode 13.

/cc @mapbox/navigation-ios @LukasPaczos