### PR TITLE
Add `TollCollection.name` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.5.0
 
 * Added the `RestStop.name` property. ([#689](https://github.com/mapbox/mapbox-directions-swift/pull/689))
+* Added the `TollCollection.name` property. ([#691](https://github.com/mapbox/mapbox-directions-swift/pull/691))
 
 ## v2.4.0
 

--- a/Sources/MapboxDirections/TollCollection.swift
+++ b/Sources/MapboxDirections/TollCollection.swift
@@ -14,12 +14,19 @@ public struct TollCollection: Codable, Equatable {
      The type of the toll collection point.
      */
     public let type: CollectionType
+    
+    /**
+     The name of the toll collection point.
+     */
+    public var name: String?
 
     private enum CodingKeys: String, CodingKey {
         case type
+        case name
     }
 
-    public init(type: CollectionType) {
+    public init(type: CollectionType, name: String? = nil) {
         self.type = type
+        self.name = name
     }
 }

--- a/Sources/MapboxDirections/TollCollection.swift
+++ b/Sources/MapboxDirections/TollCollection.swift
@@ -25,7 +25,11 @@ public struct TollCollection: Codable, Equatable {
         case name
     }
 
-    public init(type: CollectionType, name: String? = nil) {
+    public init(type: CollectionType) {
+        self.init(type: type, name: nil)
+    }
+    
+    public init(type: CollectionType, name: String?) {
         self.type = type
         self.name = name
     }

--- a/Tests/MapboxDirectionsTests/IntersectionTests.swift
+++ b/Tests/MapboxDirectionsTests/IntersectionTests.swift
@@ -15,7 +15,10 @@ class IntersectionTests: XCTestCase {
                 "mapbox_streets_v8": [
                     "class": "street_limited"
                 ],
-                "toll_collection": ["type": "toll_booth"],
+                "toll_collection": [
+                    "type": "toll_booth",
+                    "name": "test toll booth"
+                ],
             ],
             [
                 "out": 1,
@@ -69,7 +72,7 @@ class IntersectionTests: XCTestCase {
                          preferredApproachLanes: nil,
                          usableLaneIndication: nil,
                          outletRoadClasses: [.toll, .restricted],
-                         tollCollection: TollCollection(type: .booth),
+                         tollCollection: TollCollection(type: .booth, name: "test toll booth"),
                          tunnelName: nil,
                          restStop: nil,
                          isUrban: nil,


### PR DESCRIPTION
This PR fixes #690 by adding the `TollCollection.name` property.