### PR TITLE
RouteStep encoding rounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to Mapbox Directions for Swift
 
+## main
+
+* Removed limiting `RouteStep.distance`, `RouteStep.expectedTravelTime` and `RouteStep.typicalTravelTime` precision to 1 decimal digit when being encoded. ([#697](https://github.com/mapbox/mapbox-directions-swift/pull/697))
+
 ## v2.5.0
 
 * Added the `RestStop.name` property. ([#689](https://github.com/mapbox/mapbox-directions-swift/pull/689))

--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -556,9 +556,9 @@ open class RouteStep: Codable, ForeignMemberContainerClass {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(instructionsSpokenAlongStep, forKey: .instructionsSpokenAlongStep)
         try container.encodeIfPresent(instructionsDisplayedAlongStep, forKey: .instructionsDisplayedAlongStep)
-        try container.encode(distance.rounded(to: 1e1), forKey: .distance)
-        try container.encode(expectedTravelTime.rounded(to: 1e1), forKey: .expectedTravelTime)
-        try container.encodeIfPresent(typicalTravelTime?.rounded(to: 1e1), forKey: .typicalTravelTime)
+        try container.encode(distance, forKey: .distance)
+        try container.encode(expectedTravelTime, forKey: .expectedTravelTime)
+        try container.encodeIfPresent(typicalTravelTime, forKey: .typicalTravelTime)
         try container.encode(transportType, forKey: .transportType)
         
         let isRound = maneuverType == .takeRotary || maneuverType == .takeRoundabout

--- a/Tests/MapboxDirectionsTests/RouteStepTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteStepTests.swift
@@ -112,11 +112,11 @@ class RouteStepTests: XCTestCase {
             ],
             "ref": "CA 24",
             "weight": 2.5,
-            "duration": 2.5,
+            "duration": 2.55,
             "duration_typical": 2.369,
             "name": "Grove Shafter Freeway",
             "pronunciation": "ˈaɪˌfoʊ̯n ˈtɛn",
-            "distance": 24.5,
+            "distance": 24.50001,
         ] as [String: Any?]
         
         let stepData = try! JSONSerialization.data(withJSONObject: stepJSON, options: [])
@@ -139,11 +139,11 @@ class RouteStepTests: XCTestCase {
             XCTAssertEqual(step.maneuverType, .reachFork)
             XCTAssertEqual(step.instructions, "Keep right onto CA 24")
             XCTAssertEqual(step.codes, ["CA 24"])
-            XCTAssertEqual(step.expectedTravelTime, 2.5)
+            XCTAssertEqual(step.expectedTravelTime, 2.55)
             XCTAssertEqual(step.typicalTravelTime, 2.369)
             XCTAssertEqual(step.names, ["Grove Shafter Freeway"])
             XCTAssertEqual(step.phoneticNames, ["ˈaɪˌfoʊ̯n ˈtɛn"])
-            XCTAssertEqual(step.distance, 24.5)
+            XCTAssertEqual(step.distance, 24.50001)
         }
     }
     


### PR DESCRIPTION
Resolves #670 
PR removes rounding distance and travel times when encoding RouteStep. Unit test updated.