### PR TITLE
Update Xcode versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,11 +80,10 @@ jobs:
             fi
   spm-linux-job:
     docker:
-      - image: swift:5.4
+      - image: swift:5.6
     steps:
       - checkout
-      # Limiting number of parallel jobs to avoid build crash bug.
-      - run: swift build --jobs=1
+      - run: swift build
       - run: swift test
 
   spm-job:
@@ -120,7 +119,7 @@ jobs:
             carthage bootstrap --platform all --use-netrc --use-xcframeworks
   example-app-build:
     macos:
-      xcode: "12.4.0"
+      xcode: "13.4.1"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -131,25 +130,26 @@ jobs:
       - carthage-bootstrap
       - run:
           name: "Build example app"
-          command: xcodebuild -sdk iphonesimulator -project MapboxDirections.xcodeproj -scheme 'Example' -destination 'platform=iOS Simulator,OS=14.4,name=iPhone 12 Pro Max' clean build
+          command: xcodebuild -sdk iphonesimulator -project MapboxDirections.xcodeproj -scheme 'Example' -destination 'platform=iOS Simulator,OS=15.5,name=iPhone 13 Pro Max' clean build
       - save-cache
 
   build-job:
     parameters:
       xcode:
         type: string
+        default: "13.4.1"
       device:
         type: string
-        default: "iPhone 8 Plus"
+        default: "iPhone 13"
       iOS:
         type: string
-        default: "12.1"
+        default: "15.5"
       watchOS:
         type: string
-        default: "5.0"
+        default: "8.5"
       tvOS:
         type: string
-        default: "12.0"
+        default: "15.4"
       test:
         type: boolean
         default: true
@@ -198,23 +198,19 @@ workflows:
       - detect-breaking-changes:
           name: "Detect Breaking Changes"
       - build-job:
-          name: "Dev Build: Xcode 12.0"
-          xcode: "12.0.0"
-          iOS: "14.0"
-          tvOS: "14.0"
-          watchOS: "7.0"
+          name: "Dev Build: Xcode 13.4.1"
       - carthage-integration-test:
-          name: "Carthage Integration Test 12.0"
-          xcode: "12.0.0"
+          name: "Carthage Integration Test 12.5.1"
+          xcode: "12.5.1"
       - carthage-integration-test:
-          name: "Carthage Integration Test 12.4"
-          xcode: "12.4.0"
+          name: "Carthage Integration Test 13.4.1"
+          xcode: "13.4.1"
       - spm-job:
-          name: "SPM build 12.0.0"
-          xcode: "12.0.0"
+          name: "SPM build 12.5.1"
+          xcode: "12.5.1"
       - spm-job:
-          name: "SPM build 12.4.0"
-          xcode: "12.4.0"
+          name: "SPM build 13.4.1"
+          xcode: "13.4.1"
       - spm-linux-job:
           name: "SPM Ubuntu build"
       - example-app-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
             - publish-codecov
       - run:
           name: tvOS
-          command: xcodebuild -project MapboxDirections.xcodeproj -scheme 'MapboxDirections tvOS' -destination 'platform=tvOS Simulator,name=Apple TV 4K (at 1080p),OS=<< parameters.tvOS >>' clean build <<# parameters.test >>test <</ parameters.test >> <<# parameters.codecoverage >>-enableCodeCoverage YES<</ parameters.codecoverage >>
+          command: xcodebuild -project MapboxDirections.xcodeproj -scheme 'MapboxDirections tvOS' -destination 'platform=tvOS Simulator,name=Apple TV,OS=<< parameters.tvOS >>' clean build <<# parameters.test >>test <</ parameters.test >> <<# parameters.codecoverage >>-enableCodeCoverage YES<</ parameters.codecoverage >>
       - when:
           condition: << parameters.codecoverage >>
           steps:

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -9,8 +9,6 @@
 /* Begin PBXBuildFile section */
 		2B01E4B92746ABBC0002A5F7 /* RouteResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3B4C9A24EB55F60085DA64 /* RouteResponseTests.swift */; };
 		2B01E4BA2746ABBD0002A5F7 /* RouteResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3B4C9A24EB55F60085DA64 /* RouteResponseTests.swift */; };
-		2B39DD40270F034700ED68E4 /* CodingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B39DD3F270F034700ED68E4 /* CodingOperation.swift */; };
-		2B4383022549C22700A3E38B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B4383002549C22700A3E38B /* main.swift */; };
 		2B28E22327EDB2AA0029E4C1 /* ForeignMemberContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B28E22227EDB2A90029E4C1 /* ForeignMemberContainerTests.swift */; };
 		2B28E22427EDB2AA0029E4C1 /* ForeignMemberContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B28E22227EDB2A90029E4C1 /* ForeignMemberContainerTests.swift */; };
 		2B28E22527EDB2AA0029E4C1 /* ForeignMemberContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B28E22227EDB2A90029E4C1 /* ForeignMemberContainerTests.swift */; };
@@ -491,8 +489,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		2B39DD3F270F034700ED68E4 /* CodingOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CodingOperation.swift; path = Sources/MapboxDirectionsCLI/CodingOperation.swift; sourceTree = "<group>"; };
-		2B4383002549C22700A3E38B /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = main.swift; path = Sources/MapboxDirectionsCLI/main.swift; sourceTree = "<group>"; };
 		2B28E22227EDB2A90029E4C1 /* ForeignMemberContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForeignMemberContainerTests.swift; sourceTree = "<group>"; };
 		2B39DD3F270F034700ED68E4 /* CodingOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CodingOperation.swift; path = Sources/MapboxDirectionsCLI/CodingOperation.swift; sourceTree = "<group>"; };
 		2B4383002549C22700A3E38B /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = main.swift; path = Sources/MapboxDirectionsCLI/main.swift; sourceTree = "<group>"; };
@@ -1146,8 +1142,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA6C9DA01CAE442B00094FBC /* Build configuration list for PBXNativeTarget "MapboxDirections" */;
 			buildPhases = (
-				DA6C9D831CAE442B00094FBC /* Sources */,
 				DA6C9D851CAE442B00094FBC /* Headers */,
+				DA6C9D831CAE442B00094FBC /* Sources */,
 				DA6C9D861CAE442B00094FBC /* Resources */,
 				7AC435C54F754F3C6A047D02 /* Frameworks */,
 			);

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -1052,8 +1052,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA1A10C41D00F8FF009F82FA /* Build configuration list for PBXNativeTarget "MapboxDirectionsMac" */;
 			buildPhases = (
-				DA1A10AA1D00F8FF009F82FA /* Sources */,
 				DA1A10AC1D00F8FF009F82FA /* Headers */,
+				DA1A10AA1D00F8FF009F82FA /* Sources */,
 				DA1A10AD1D00F8FF009F82FA /* Resources */,
 				653A4672B83CA07822A37632 /* Frameworks */,
 			);
@@ -1088,8 +1088,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA1A10EA1D0101ED009F82FA /* Build configuration list for PBXNativeTarget "MapboxDirectionsTV" */;
 			buildPhases = (
-				DA1A10D01D0101ED009F82FA /* Sources */,
 				DA1A10D21D0101ED009F82FA /* Headers */,
+				DA1A10D01D0101ED009F82FA /* Sources */,
 				DA1A10D31D0101ED009F82FA /* Resources */,
 				84AE54CA0DD2836DC232F06B /* Frameworks */,
 			);
@@ -1124,8 +1124,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA1A11001D010361009F82FA /* Build configuration list for PBXNativeTarget "MapboxDirectionsWatch" */;
 			buildPhases = (
-				DA1A10F61D010361009F82FA /* Sources */,
 				DA1A10F81D010361009F82FA /* Headers */,
+				DA1A10F61D010361009F82FA /* Sources */,
 				DA1A10F91D010361009F82FA /* Resources */,
 				E05B24A0DFB05E8378736C51 /* Frameworks */,
 			);


### PR DESCRIPTION
CircleCI is [removing old Xcode images](https://discuss.circleci.com/t/xcode-image-deprecation/44294?mkt_tok=NDg1LVpNSC02MjYAAAGE6MeEggPLUM-i-bTcXMfA2ZTjvhtuQlX3L3UKSpmj0vFOZymLJ6iZjMzElf5CeHTEGAJL99zdsiNX_WDfu7k) in 2 weeks, so we should update our CI pipeline.

PR is mostly bumping Xcode and runtime versions, but also fixed a dependency cycle errors in new Xcode version:

<img width="1130" alt="image" src="https://user-images.githubusercontent.com/1976216/179772896-3034ce8b-cdc4-4b90-93c8-327ee7b78eaf.png">
