### PR TITLE
Document Xcode 13 as minimum Xcode version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.7.0
 
+* Xcode 13.0 or above is now required to build MapboxDirections from source. ([#725](https://github.com/mapbox/mapbox-directions-swift/pull/725))
 * Added `Waypoint.allowsSnappingToStaticallyClosedRoad` property to allow snapping the waypoint’s location to a statically (long-term) closed part of a road. ([#721](https://github.com/mapbox/mapbox-directions-swift/pull/721))
 
 ## v2.6.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To contribute code changes to this project, use either Carthage or Swift Package
 
 ### Using Carthage
 
-1. Install Xcode 12 and [Carthage](https://github.com/Carthage/Carthage/) v0.38 or above.
+1. Install Xcode 13 and [Carthage](https://github.com/Carthage/Carthage/) v0.38 or above.
 1. Run `carthage bootstrap --platform all --use-xcframeworks`.
 1. Once the Carthage build finishes, open MapboxDirections.xcodeproj in Xcode and build the MapboxDirections Mac scheme.
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ This repository contains an example application that demonstrates how to use the
 ## System requirements
 
 * One of the following package managers:
-   * CocoaPods (CocoaPods 1.10 or above if using Xcode 12)
+   * CocoaPods 1.10 or above
    * Carthage 0.38 or above
    * Swift Package Manager 5.3 or above
-* Xcode 12 or above
+* Xcode 13 or above
 * One of the following operating systems:
    * iOS 10.0 or above
    * macOS 10.12.0 or above


### PR DESCRIPTION
As a followup to #717, if we’re dropping Xcode 12 from the CI configuration, then this project effectively no longer supports Xcode 12.

/cc @mapbox/navigation-ios