### PR TITLE
Require Xcode 13.0+, Swift 5.5+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,17 +200,17 @@ workflows:
       - build-job:
           name: "Dev Build: Xcode 13.4.1"
       - carthage-integration-test:
-          name: "Carthage Integration Test 12.5.1"
-          xcode: "12.5.1"
+          name: "Carthage Integration Test 13.0.0"
+          xcode: "13.0.0"
       - carthage-integration-test:
-          name: "Carthage Integration Test 13.4.1"
-          xcode: "13.4.1"
+          name: "Carthage Integration Test 14.0.0"
+          xcode: "14.0.0"
       - spm-job:
-          name: "SPM build 12.5.1"
-          xcode: "12.5.1"
+          name: "SPM build 13.0.0"
+          xcode: "13.0.0"
       - spm-job:
-          name: "SPM build 13.4.1"
-          xcode: "13.4.1"
+          name: "SPM build 14.0.0"
+          xcode: "14.0.0"
       - spm-linux-job:
           name: "SPM Ubuntu build"
       - example-app-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,8 +206,8 @@ workflows:
           name: "Carthage Integration Test 14.0.0"
           xcode: "14.0.0"
       - spm-job:
-          name: "SPM build 13.0.0"
-          xcode: "13.0.0"
+          name: "SPM build 13.3.1"
+          xcode: "13.3.1"
       - spm-job:
           name: "SPM build 14.0.0"
           xcode: "14.0.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.7.0
 
-* Xcode 13.0 or above is now required to build MapboxDirections from source. ([#725](https://github.com/mapbox/mapbox-directions-swift/pull/725))
+* Xcode 13.0 or above and Swift 5.5 or above are now required to build MapboxDirections from source. ([#725](https://github.com/mapbox/mapbox-directions-swift/pull/725), [#727](https://github.com/mapbox/mapbox-directions-swift/pull/727))
 * Added `Waypoint.allowsSnappingToStaticallyClosedRoad` property to allow snapping the waypoint’s location to a statically (long-term) closed part of a road. ([#721](https://github.com/mapbox/mapbox-directions-swift/pull/721))
 
 ## v2.6.0

--- a/MapboxDirections.podspec
+++ b/MapboxDirections.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.module_name = "MapboxDirections"
-  s.swift_version = "5.0"
+  s.swift_version = "5.5"
 
   s.dependency "Polyline", "~> 5.0"
   s.dependency "Turf", "~> 2.4"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This repository contains an example application that demonstrates how to use the
 * One of the following package managers:
    * CocoaPods 1.10 or above
    * Carthage 0.38 or above
-   * Swift Package Manager 5.3 or above
+   * Swift Package Manager 5.5 or above
 * Xcode 13 or above
 * One of the following operating systems:
    * iOS 10.0 or above


### PR DESCRIPTION
The Carthage integration test builds on CircleCI now build in Xcode 13.0 and 14.0. The Swift Package manager integration test builds now build in Xcode 13.3.1  and 14.0. In general, the minimum supported Swift Package Manager version is 5.5, the same version that ships with Xcode 13.0.

#717 dropped Xcode 12 from CircleCI jobs that build the library using Xcode’s build system, but it left Xcode 12 in place for Carthage and SPM integration tests. I missed the latter in #725 when declaring that this library no longer supports Xcode 12. But I think we might as well say so formally, for all package managers, for consistency with the navigation SDK (mapbox/mapbox-navigation-ios#4063).

The App Store no longer accepts applications built in Xcode 12, so the only benefit to keeping Xcode 12 support would be Swift command line tools and macOS applications that don’t need to go through the App Store. Unlike the main library, the command line tool is not yet subject to the API stability guarantee.

The CircleCI configuration tests SPM integration in Xcode 13.3.1 because CircleCI’s Xcode 13 image runs on macOS 11.5.2, whereas ArgumentParser only supports macOS 12 and above.

/cc @mapbox/navigation-ios