### PR TITLE
Accept request URL in lieu of configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added `Waypoint.allowsSnappingToStaticallyClosedRoad` property to allow snapping the waypoint’s location to a statically (long-term) closed part of a road. ([#721](https://github.com/mapbox/mapbox-directions-swift/pull/721))
 * `RouteOptions(url:)` now returns `nil` if given a Mapbox Map Matching API request URL, and `MatchOptions(url:)` returns `nil` if given a Mapbox Directions API request URL. ([#728](https://github.com/mapbox/mapbox-directions-swift/pull/728))
 * When the `MAPBOX_ACCESS_TOKEN` environment variable is unset, the `mapbox-directions-swift` command line tool exits with an error code instead of crashing. ([#728](https://github.com/mapbox/mapbox-directions-swift/pull/728))
+* The `mapbox-directions-swift` command line tool now connects to the API endpoint in the `MAPBOX_HOST` environment variable, if specified. ([#728](https://github.com/mapbox/mapbox-directions-swift/pull/728))
 
 ## v2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,20 @@
 
 ## 2.7.0
 
+### Packaging
+
 * Xcode 13.0 or above and Swift 5.5 or above are now required to build MapboxDirections from source. ([#725](https://github.com/mapbox/mapbox-directions-swift/pull/725), [#727](https://github.com/mapbox/mapbox-directions-swift/pull/727))
+
+### Command line tool
+
+* Removed the `--config` option. Instead, pass in either the path to a JSON configuration file or the full URL to a Mapbox Directions API or Mapbox Map Matching API request. ([#726](https://github.com/mapbox/mapbox-directions-swift/pull/726)) 
+* When the `MAPBOX_ACCESS_TOKEN` environment variable is unset, the tool exits with an error code instead of crashing. ([#728](https://github.com/mapbox/mapbox-directions-swift/pull/728))
+* The tool now connects to the API endpoint in the `MAPBOX_HOST` environment variable, if specified. ([#728](https://github.com/mapbox/mapbox-directions-swift/pull/728))
+
+### Other changes
+
 * Added `Waypoint.allowsSnappingToStaticallyClosedRoad` property to allow snapping the waypoint’s location to a statically (long-term) closed part of a road. ([#721](https://github.com/mapbox/mapbox-directions-swift/pull/721))
 * `RouteOptions(url:)` now returns `nil` if given a Mapbox Map Matching API request URL, and `MatchOptions(url:)` returns `nil` if given a Mapbox Directions API request URL. ([#728](https://github.com/mapbox/mapbox-directions-swift/pull/728))
-* When the `MAPBOX_ACCESS_TOKEN` environment variable is unset, the `mapbox-directions-swift` command line tool exits with an error code instead of crashing. ([#728](https://github.com/mapbox/mapbox-directions-swift/pull/728))
-* The `mapbox-directions-swift` command line tool now connects to the API endpoint in the `MAPBOX_HOST` environment variable, if specified. ([#728](https://github.com/mapbox/mapbox-directions-swift/pull/728))
 
 ## v2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Xcode 13.0 or above and Swift 5.5 or above are now required to build MapboxDirections from source. ([#725](https://github.com/mapbox/mapbox-directions-swift/pull/725), [#727](https://github.com/mapbox/mapbox-directions-swift/pull/727))
 * Added `Waypoint.allowsSnappingToStaticallyClosedRoad` property to allow snapping the waypoint’s location to a statically (long-term) closed part of a road. ([#721](https://github.com/mapbox/mapbox-directions-swift/pull/721))
 * `RouteOptions(url:)` now returns `nil` if given a Mapbox Map Matching API request URL, and `MatchOptions(url:)` returns `nil` if given a Mapbox Directions API request URL. ([#728](https://github.com/mapbox/mapbox-directions-swift/pull/728))
+* When the `MAPBOX_ACCESS_TOKEN` environment variable is unset, the `mapbox-directions-swift` command line tool exits with an error code instead of crashing. ([#728](https://github.com/mapbox/mapbox-directions-swift/pull/728))
 
 ## v2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Xcode 13.0 or above and Swift 5.5 or above are now required to build MapboxDirections from source. ([#725](https://github.com/mapbox/mapbox-directions-swift/pull/725), [#727](https://github.com/mapbox/mapbox-directions-swift/pull/727))
 * Added `Waypoint.allowsSnappingToStaticallyClosedRoad` property to allow snapping the waypoint’s location to a statically (long-term) closed part of a road. ([#721](https://github.com/mapbox/mapbox-directions-swift/pull/721))
+* `RouteOptions(url:)` now returns `nil` if given a Mapbox Map Matching API request URL, and `MatchOptions(url:)` returns `nil` if given a Mapbox Directions API request URL. ([#728](https://github.com/mapbox/mapbox-directions-swift/pull/728))
 
 ## v2.6.0
 

--- a/CommandLineTool.md
+++ b/CommandLineTool.md
@@ -23,12 +23,16 @@ To connect to an API endpoint other than the default Mapbox API endpoint, set th
 
 `mapbox-directions-swift` is a useful tool for mobile quality assurance. This tool can be used to verify a response to ensure proper Directions API integration, get a [GPX](https://wikipedia.org/wiki/GPS_Exchange_Format) trace that can be used in the Xcode Simulator, and convert a Directions API request to an Options object.
 
+### Arguments
+
+The sole argument is either:
+
+* The path to a JSON file that contains a serialized `RouteOptions` or `MatchOptions`
+* The URL of a Mapbox Directions API or Mapbox Map Matching API request
+
 ### Options
 `--input`
-An optional flag for the filepath to the input JSON. If this flag is not used, `mapbox-directions-swift` will fallback to a Directions API request. To request using specific coordinates, specify coordinates using `--waypoints` or a Directions API request using `--url`.
-
-`--config`
-An optional flag for the filepath to the JSON, containing serialized Options data.
+An optional flag for the filepath to the input JSON. If this flag is not used, `mapbox-directions-swift` will fallback to a Directions API request.
 
 `--output`
 An optional flag for the filepath to save the conversion result. If no filepath is provided, the result will output to the shell. If you want a GPX trace that can be easily uploaded to Xcode, provide an output filepath with this flag.

--- a/CommandLineTool.md
+++ b/CommandLineTool.md
@@ -17,6 +17,8 @@ To run the `MapboxDirectionsCLI` within Xcode, select the `MapboxDirectionsCLI` 
 
 A [Mapbox access token](https://account.mapbox.com/access-tokens/) is required for some operations. Set the `MAPBOX_ACCESS_TOKEN` environment variable to your access token.
 
+To connect to an API endpoint other than the default Mapbox API endpoint, set the `MAPBOX_HOST` environment variable to the base URL.
+
 ## Usage and Recipes
 
 `mapbox-directions-swift` is a useful tool for mobile quality assurance. This tool can be used to verify a response to ensure proper Directions API integration, get a [GPX](https://wikipedia.org/wiki/GPS_Exchange_Format) trace that can be used in the Xcode Simulator, and convert a Directions API request to an Options object.

--- a/CommandLineTool.md
+++ b/CommandLineTool.md
@@ -13,6 +13,10 @@ To run (and build if it wasn't yet) `MapboxDirectionsCLI` and see usage:
 
 To run the `MapboxDirectionsCLI` within Xcode, select the `MapboxDirectionsCLI` target and edit the scheme to include arguments passed at launch.
 
+## Configuration
+
+A [Mapbox access token](https://account.mapbox.com/access-tokens/) is required for some operations. Set the `MAPBOX_ACCESS_TOKEN` environment variable to your access token.
+
 ## Usage and Recipes
 
 `mapbox-directions-swift` is a useful tool for mobile quality assurance. This tool can be used to verify a response to ensure proper Directions API integration, get a [GPX](https://wikipedia.org/wiki/GPS_Exchange_Format) trace that can be used in the Xcode Simulator, and convert a Directions API request to an Options object.

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -258,6 +258,11 @@ open class DirectionsOptions: Codable {
         self.init(waypoints: waypoints,
                   profileIdentifier: profileIdentifier,
                   queryItems: URLComponents(url: url, resolvingAgainstBaseURL: true)?.queryItems)
+        
+        // Distinguish between Directions API and Map Matching API URLs.
+        guard url.pathComponents.dropLast().joined(separator: "/").hasSuffix(abridgedPath) else {
+            return nil
+        }
     }
     
     

--- a/Sources/MapboxDirectionsCLI/CodingOperation.swift
+++ b/Sources/MapboxDirectionsCLI/CodingOperation.swift
@@ -5,12 +5,6 @@ import Turf
 import FoundationNetworking
 #endif
 
-let accessToken: String? =
-    ProcessInfo.processInfo.environment["MAPBOX_ACCESS_TOKEN"] ??
-    UserDefaults.standard.string(forKey: "MBXAccessToken")
-let credentials = Credentials(accessToken: accessToken!)
-private let directions = Directions(credentials: credentials)
-
 protocol DirectionsResultsProvider {
     var directionsResults: [DirectionsResult]? { get }
 }
@@ -28,6 +22,7 @@ class CodingOperation<ResponseType : Codable & DirectionsResultsProvider, Option
     // MARK: - Parameters
     
     let options: ProcessingOptions
+    let credentials: Credentials
     
     // MARK: - Helper methods
     
@@ -128,6 +123,7 @@ class CodingOperation<ResponseType : Codable & DirectionsResultsProvider, Option
         
         var responseData: Data!
         
+        let directions = Directions(credentials: credentials)
         let url = directions.url(forCalculating: directionsOptions)
         let urlSession = URLSession(configuration: .ephemeral)
 
@@ -146,8 +142,9 @@ class CodingOperation<ResponseType : Codable & DirectionsResultsProvider, Option
         return (responseData)
     }
     
-    init(options: ProcessingOptions) {
+    init(options: ProcessingOptions, credentials: Credentials) {
         self.options = options
+        self.credentials = credentials
     }
     
     // MARK: - Command implementation

--- a/Sources/MapboxDirectionsCLI/main.swift
+++ b/Sources/MapboxDirectionsCLI/main.swift
@@ -4,14 +4,13 @@ import Foundation
 import MapboxDirections
 import ArgumentParser
 
-
 struct ProcessingOptions: ParsableArguments {
     
     @Option(name: [.short, .customLong("input")], help: "[Optional] Filepath to the input JSON. If no filepath provided - will fall back to Directions API request using locations in config file.")
     var inputPath: String?
     
-    @Option(name: [.short, .customLong("config")], help: "Filepath to the JSON, containing serialized Options data.")
-    var configPath: String
+    @Argument(help: "Path to a JSON file containing serialized RouteOptions or MatchOptions properties, or the full URL of a Mapbox Directions API or Mapbox Map Matching API request.")
+    var config: String
     
     @Option(name: [.short, .customLong("output")], help: "[Optional] Output filepath to save the conversion result. If no filepath provided - will output to the shell.")
     var outputPath: String?
@@ -53,9 +52,8 @@ struct Command: ParsableCommand {
     )
     
     fileprivate static func validateInput(_ options: ProcessingOptions) throws {
-        
-        guard FileManager.default.fileExists(atPath: options.configPath) else {
-            throw ValidationError("Options JSON file `\(options.configPath)` does not exist.")
+        if !FileManager.default.fileExists(atPath: (options.config as NSString).expandingTildeInPath) && URL(string: options.config) == nil {
+            throw ValidationError("Configuration is a nonexistent file or invalid request URL: \(options.config)")
         }
     }
 }

--- a/Sources/MapboxDirectionsCLI/main.swift
+++ b/Sources/MapboxDirectionsCLI/main.swift
@@ -27,6 +27,16 @@ struct ProcessingOptions: ParsableArguments {
 }
 
 struct Command: ParsableCommand {
+    static var accessToken: String {
+        get throws {
+            guard let accessToken = ProcessInfo.processInfo.environment["MAPBOX_ACCESS_TOKEN"] ??
+                    UserDefaults.standard.string(forKey: "MBXAccessToken") else {
+                throw ValidationError("A Mapbox access token is required. Go to <https://account.mapbox.com/access-tokens/>, then set the MAPBOX_ACCESS_TOKEN environment variable to your access token.")
+            }
+            return accessToken
+        }
+    }
+    
     static var configuration = CommandConfiguration(
         commandName: "mapbox-directions-swift",
         abstract: "'mapbox-directions-swift' is a command line tool, designed to round-trip an arbitrary, JSON-formatted Directions or Map Matching API response through model objects and back to JSON.",
@@ -54,7 +64,8 @@ extension Command {
         }
         
         mutating func run() throws {
-            try CodingOperation<MapMatchingResponse, MatchOptions>(options: options).execute()
+            let credentials = Credentials(accessToken: try accessToken)
+            try CodingOperation<MapMatchingResponse, MatchOptions>(options: options, credentials: credentials).execute()
         }
     }
 }
@@ -72,7 +83,8 @@ extension Command {
         }
         
         mutating func run() throws {
-            try CodingOperation<RouteResponse, RouteOptions>(options: options).execute()
+            let credentials = Credentials(accessToken: try accessToken)
+            try CodingOperation<RouteResponse, RouteOptions>(options: options, credentials: credentials).execute()
         }
     }
 }

--- a/Tests/MapboxDirectionsTests/MatchOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/MatchOptionsTests.swift
@@ -26,7 +26,7 @@ class MatchOptionsTests: XCTestCase {
         XCTAssertEqual(unarchivedOptions.resamplesTraces, options.resamplesTraces)
     }
     
-    func testURLCoding() {
+    func testURLCoding() throws {
         
         let originalOptions = testMatchOptions
         originalOptions.resamplesTraces = true
@@ -62,6 +62,10 @@ class MatchOptionsTests: XCTestCase {
         
         XCTAssertEqual(decodedOptions.profileIdentifier, originalOptions.profileIdentifier)
         XCTAssertEqual(decodedOptions.resamplesTraces, originalOptions.resamplesTraces)
+        
+        let matchURL = try XCTUnwrap(URL(string: "https://api.mapbox.com/matching/v5/mapbox/driving/-121.913565,37.331832;-121.916282,37.328707.json"))
+        XCTAssertNotNil(MatchOptions(url: matchURL))
+        XCTAssertNil(RouteOptions(url: matchURL))
     }
     
     // MARK: API name-handling tests

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -119,7 +119,7 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertEqual(unarchivedOptions.maximumHeight, routeOptions.maximumHeight)
     }
     
-    func testURLCoding() {
+    func testURLCoding() throws {
         
         let originalOptions = testRouteOptions
         originalOptions.includesAlternativeRoutes = true
@@ -191,6 +191,10 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertNil(decodedOptions.arriveBy)
         // URL encoding skips seconds, so we check that dates are within 1 minute delta
         XCTAssertTrue(abs(decodedOptions.departAt!.timeIntervalSince(originalOptions.departAt!)) < 60)
+        
+        let routeURL = try XCTUnwrap(URL(string: "https://api.mapbox.com/directions/v5/mapbox/driving-traffic/-121.913565,37.331832;-121.916282,37.328707.json"))
+        XCTAssertNotNil(RouteOptions(url: routeURL))
+        XCTAssertNil(MatchOptions(url: routeURL))
     }
     
     // MARK: API name-handling tests


### PR DESCRIPTION
Overhauled the command line tool’s configuration option. Instead of the `--config` option that takes a JSON configuration file path, the tool now takes a single positional argument that can either be a JSON configuration file path or a Directions API or Map Matching API request URL. When you pass in a request URL, the URL is round-tripped through a DirectionsOptions object back to a URL, exercising the entire typical code path (and then some).

But if you do decide to pass in a JSON configuration file instead of a URL, the command line tool now respects the `MAPBOX_HOST` environment variable alongside the `MAPBOX_ACCESS_TOKEN` environment variable. An access token is scoped to a single API endpoint, so this configuration option makes it possible to run the tool against a proxy or staging server for testing purposes.

`RouteOptions(url:)` now returns `nil` if given a Mapbox Map Matching API request URL, and `MatchOptions(url:)` returns `nil` if given a Mapbox Directions API request URL. Previously, you could mix and match URLs to convert between RouteOptions and MatchOptions. Now, you’ll need to use JSONEncoder and JSONDecoder as well: 

```swift
guard let url = URL(string: "https://api.mapbox.com/directions/v5/mapbox/driving-traffic/…"),
    let routeOptions = RouteOptions(url: url),
    let encodedOptions = try? JSONEncoder().encode(self) else { return }
try JSONDecoder().decode(MatchOptions.self, from: encodedOptions)
```

#564 would unblock a more convenient conversion workflow.

Some tangential changes along the way:

* When the `MAPBOX_ACCESS_TOKEN` environment variable is unset, the tool exits with an error code instead of crashing.
* When a JSON configuration file path is passed into the tool, any tilde is expanded during validation, fixing an issue where an otherwise valid file path got rejected.
* Removed mentions of the `--waypoints` and `--url` options from the command line tool’s documentation that probably came from #580.

Fixes #692 and fixes #724. Supersedes #580. Depends on #727.

/cc @mapbox/navigation-ios @purew