### PR TITLE
Add documentation to `RouteResponse` and `MapMatchingResponse`

### DIFF
--- a/Sources/MapboxDirections/MapMatching/MapMatchingResponse.swift
+++ b/Sources/MapboxDirections/MapMatching/MapMatchingResponse.swift
@@ -8,9 +8,6 @@ import Turf
  A `MapMatchingResponse` object is a structure that corresponds to a map matching response returned by the Mapbox Map Matching API.
  */
 public struct MapMatchingResponse: ForeignMemberContainer {
-    /**
-     Unrecognized properties that are documented as "beta" properties in the Mapbox Map Matching API response.
-     */
     public var foreignMembers: JSONObject = [:]
     
     /**

--- a/Sources/MapboxDirections/MapMatching/MapMatchingResponse.swift
+++ b/Sources/MapboxDirections/MapMatching/MapMatchingResponse.swift
@@ -4,15 +4,39 @@ import FoundationNetworking
 #endif
 import Turf
 
+/**
+ A `MapMatchingResponse` object is a structure that corresponds to a map matching response returned by the Mapbox Map Matching API.
+ */
 public struct MapMatchingResponse: ForeignMemberContainer {
+    /**
+     Unrecognized properties that are documented as "beta" properties in the Mapbox Map Matching API response.
+     */
     public var foreignMembers: JSONObject = [:]
     
+    /**
+     The raw HTTP response from the Map Matching API.
+     */
     public let httpResponse: HTTPURLResponse?
     
+    /**
+     An array of `Match` objects.
+     */
     public var matches : [Match]?
+    
+    /**
+     An array of `Tracepoint` objects that represent the location an input point was matched with, in the order in which they were matched.
+     This property will be `nil` if a trace point is omitted by the Map Matching API because it is an outlier.
+     */
     public var tracepoints: [Tracepoint?]?
     
+    /**
+     The criteria for the map matching response.
+     */
     public let options: MatchOptions
+    
+    /**
+     The credentials used to make the request.
+     */
     public let credentials: Credentials
     
     /**

--- a/Sources/MapboxDirections/RouteResponse.swift
+++ b/Sources/MapboxDirections/RouteResponse.swift
@@ -13,9 +13,6 @@ public enum ResponseOptions {
  A `RouteResponse` object is a structure that corresponds to a directions response returned by the Mapbox Directions API.
  */
 public struct RouteResponse: ForeignMemberContainer {
-    /**
-     Unrecognized properties that are documented as "beta" properties in the Mapbox Directions API response.
-     */
     public var foreignMembers: JSONObject = [:]
     
     /**
@@ -24,12 +21,13 @@ public struct RouteResponse: ForeignMemberContainer {
     public let httpResponse: HTTPURLResponse?
     
     /**
-     The response identifier used to request the route.
+     The unique identifier that the Mapbox Directions API has assigned to this response.
      */
     public let identifier: String?
     
     /**
-     An array of `Route` objects ordered by descending recommendation rank. This property may contain at most two `Route`s.
+     An array of `Route` objects sorted from most recommended to least recommended. A route may be highly recommended based on characteristics such as expected travel time or distance.
+     This property contains a maximum of two `Route`s.
      */
     public var routes: [Route]? {
         didSet {
@@ -39,6 +37,8 @@ public struct RouteResponse: ForeignMemberContainer {
     
     /**
      An array of `Waypoint` objects in the order of the input coordinates. Each `Waypoint` is an input coordinate snapped to the road and path network.
+    
+     This property omits the waypoint corresponding to any waypoint in `RouteOptions.waypoints` that has `Waypoint.separatesLegs` set to `true`.
      */
     public let waypoints: [Waypoint]?
     

--- a/Sources/MapboxDirections/RouteResponse.swift
+++ b/Sources/MapboxDirections/RouteResponse.swift
@@ -9,20 +9,47 @@ public enum ResponseOptions {
     case match(MatchOptions)
 }
 
+/**
+ A `RouteResponse` object is a structure that corresponds to a directions response returned by the Mapbox Directions API.
+ */
 public struct RouteResponse: ForeignMemberContainer {
+    /**
+     Unrecognized properties that are documented as "beta" properties in the Mapbox Directions API response.
+     */
     public var foreignMembers: JSONObject = [:]
     
+    /**
+     The raw HTTP response from the Directions API.
+     */
     public let httpResponse: HTTPURLResponse?
     
+    /**
+     The response identifier used to request the route.
+     */
     public let identifier: String?
+    
+    /**
+     An array of `Route` objects ordered by descending recommendation rank. This property may contain at most two `Route`s.
+     */
     public var routes: [Route]? {
         didSet {
             updateRoadClassExclusionViolations()
         }
     }
+    
+    /**
+     An array of `Waypoint` objects in the order of the input coordinates. Each `Waypoint` is an input coordinate snapped to the road and path network.
+     */
     public let waypoints: [Waypoint]?
     
+    /**
+     The criteria for the directions response.
+     */
     public let options: ResponseOptions
+    
+    /**
+     The credentials used to make the request.
+     */
     public let credentials: Credentials
     
     /**


### PR DESCRIPTION
This PR fixes #732 by adding documentation comments to `RouteResponse` and `MapMatchingResponse` that will show up in the jazzy-generated API reference.