### PR TITLE
Fix SPM warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
             resources: [
                 .process("Fixtures"),
             ]),
-        .target(
+        .executableTarget(
             name: "MapboxDirectionsCLI",
             dependencies: [
                 "MapboxDirections",


### PR DESCRIPTION
Fixes Xcode warning during package resolving step:

<img width="699" alt="image" src="https://user-images.githubusercontent.com/1976216/191241618-32db0419-fb48-4b9b-96c7-a439d2595302.png">
