### PR TITLE
Add `Waypoint.layer` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Packaging
 
 * This library now requires a minimum deployment target of iOS 12.0 or above, macOS 10.14.0 or above, tvOS 12.0 or above, or watchOS 5.0 or above. Older operating system versions are no longer supported. ([#736](https://github.com/mapbox/mapbox-directions-swift/pull/736))
+* Added the `Directions.refreshRoute(responseIdentifier:routeIndex:fromLegAtIndex:currentRouteShapeIndex:completionHandler:)` method, which takes the index into the route geometry at which to begin refreshing, as well as corresponding `Directions.urlRequest(forRefreshing responseIdentifier:routeIndex:fromLegAtIndex:currentRouteShapeIndex:)`, `RouteRefreshResponse.refreshLegAttributes(from:legIndex:legShapeIndex:)`, and `RouteRefreshResponse.refreshLegIncidents(from:legIndex:legShapeIndex:)` methods. ([#733](https://github.com/mapbox/mapbox-directions-swift/pull/733/files))
+
+### Other Changes
+
+* Added the `Waypoint.layer` property which influences the layer of road from which a route starts from that waypoint. This property is useful for avoiding ambiguity in the case of multi-level roads (such as a tunnel under a road). ([#745](https://github.com/mapbox/mapbox-directions-swift/pull/745))
 
 ## 2.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,10 @@
 ### Packaging
 
 * This library now requires a minimum deployment target of iOS 12.0 or above, macOS 10.14.0 or above, tvOS 12.0 or above, or watchOS 5.0 or above. Older operating system versions are no longer supported. ([#736](https://github.com/mapbox/mapbox-directions-swift/pull/736))
-* Added the `Directions.refreshRoute(responseIdentifier:routeIndex:fromLegAtIndex:currentRouteShapeIndex:completionHandler:)` method, which takes the index into the route geometry at which to begin refreshing, as well as corresponding `Directions.urlRequest(forRefreshing responseIdentifier:routeIndex:fromLegAtIndex:currentRouteShapeIndex:)`, `RouteRefreshResponse.refreshLegAttributes(from:legIndex:legShapeIndex:)`, and `RouteRefreshResponse.refreshLegIncidents(from:legIndex:legShapeIndex:)` methods. ([#733](https://github.com/mapbox/mapbox-directions-swift/pull/733/files))
 
 ### Other Changes
 
-* Added the `Waypoint.layer` property which influences the layer of road from which a route starts from that waypoint. This property is useful for avoiding ambiguity in the case of multi-level roads (such as a tunnel under a road). ([#745](https://github.com/mapbox/mapbox-directions-swift/pull/745))
+* Added the `Waypoint.layer` property, which can ensure that the route begins on the correct road if it is above or below another road. ([#745](https://github.com/mapbox/mapbox-directions-swift/pull/745))
 
 ## 2.7.0
 

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -435,7 +435,7 @@ open class RouteOptions: DirectionsOptions {
             params.append(URLQueryItem(name: CodingKeys.waypointTargets.stringValue, value: targetCoordinates))
         }
         
-        if waypoints.first(where: { $0.layer != nil} ) != nil {
+        if waypoints.contains(where: { $0.layer != nil }) {
             let layers = waypoints.map { $0.layer?.description ?? "" }.joined(separator: ";")
             params.append(URLQueryItem(name: CodingKeys.layers.stringValue, value: layers))
         }

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -92,13 +92,10 @@ open class RouteOptions: DirectionsOptions {
             self.maximumWeight = Measurement(value: doubleValue, unit: UnitMass.metricTons)
         }
         
-//        if waypoints.first(where: { $0.layer != nil} ) != nil {
-//            let layers = waypoints.map { $0.layer?.description ?? ";" }.joined()
-//            params.append(URLQueryItem(name: CodingKeys.layers.stringValue, value: layers))
-//        }
-        
         if let mappedValue = mappedQueryItems[CodingKeys.layers.stringValue] {
-            waypoints.
+            zip(waypoints, mappedValue.components(separatedBy: ";")).forEach {
+                $0.layer = Int($1) ?? nil
+            }
         }
         
         let formatter = DateFormatter.ISO8601DirectionsFormatter()
@@ -157,7 +154,7 @@ open class RouteOptions: DirectionsOptions {
         case waypointTargets = "waypoint_targets"
         case arriveBy = "arrive_by"
         case departAt = "depart_at"
-        case layers
+        case layers = "layers"
     }
     
     public override func encode(to encoder: Encoder) throws {
@@ -439,7 +436,7 @@ open class RouteOptions: DirectionsOptions {
         }
         
         if waypoints.first(where: { $0.layer != nil} ) != nil {
-            let layers = waypoints.map { $0.layer?.description ?? ";" }.joined()
+            let layers = waypoints.map { $0.layer?.description ?? "" }.joined(separator: ";")
             params.append(URLQueryItem(name: CodingKeys.layers.stringValue, value: layers))
         }
         

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -92,6 +92,14 @@ open class RouteOptions: DirectionsOptions {
             self.maximumWeight = Measurement(value: doubleValue, unit: UnitMass.metricTons)
         }
         
+//        if waypoints.first(where: { $0.layer != nil} ) != nil {
+//            let layers = waypoints.map { $0.layer?.description ?? ";" }.joined()
+//            params.append(URLQueryItem(name: CodingKeys.layers.stringValue, value: layers))
+//        }
+        
+        if let mappedValue = mappedQueryItems[CodingKeys.layers.stringValue] {
+            waypoints.
+        }
         
         let formatter = DateFormatter.ISO8601DirectionsFormatter()
         if let mappedValue = mappedQueryItems[CodingKeys.departAt.stringValue],
@@ -149,6 +157,7 @@ open class RouteOptions: DirectionsOptions {
         case waypointTargets = "waypoint_targets"
         case arriveBy = "arrive_by"
         case departAt = "depart_at"
+        case layers
     }
     
     public override func encode(to encoder: Encoder) throws {
@@ -427,6 +436,11 @@ open class RouteOptions: DirectionsOptions {
         if waypoints.first(where: { $0.targetCoordinate != nil }) != nil {
             let targetCoordinates = waypoints.filter { $0.separatesLegs }.map { $0.targetCoordinate?.requestDescription ?? "" }.joined(separator: ";")
             params.append(URLQueryItem(name: CodingKeys.waypointTargets.stringValue, value: targetCoordinates))
+        }
+        
+        if waypoints.first(where: { $0.layer != nil} ) != nil {
+            let layers = waypoints.map { $0.layer?.description ?? ";" }.joined()
+            params.append(URLQueryItem(name: CodingKeys.layers.stringValue, value: layers))
         }
         
         if let initialManeuverAvoidanceRadius = initialManeuverAvoidanceRadius {

--- a/Sources/MapboxDirections/Waypoint.swift
+++ b/Sources/MapboxDirections/Waypoint.swift
@@ -181,11 +181,11 @@ public class Waypoint: Codable, ForeignMemberContainerClass {
     public var snappedDistance: LocationDistance?
     
     /**
-     The layer of road that the waypoint is positioned which is used to filter the road segment that the waypoint will be placed on in Z-order. It is useful for avoiding ambiguity in the case of multi-level roads (such as a tunnel under a road).
+     The [layer](https://wiki.openstreetmap.org/wiki/Key:layer) of road that the waypoint is positioned which is used to filter the road segment that the waypoint will be placed on in Z-order. It is useful for avoiding ambiguity in the case of multi-level roads (such as a tunnel under a road).
      
-     This property corresponds to the ['layers'](https://docs.mapbox.com/api/navigation/directions/#optional-parameters) query parameter in the Mapbox Directions API. If a matching layer is not found, the Mapbox Directions API will choose a suitable layer according to the other procided parameters.
+     This property corresponds to the [`layers`](https://docs.mapbox.com/api/navigation/directions/#optional-parameters) query parameter in the Mapbox Directions API. If a matching layer is not found, the Mapbox Directions API will choose a suitable layer according to the other  provided `DirectionsOptions` and `Waypoint` properties.
      
-     By default, this property is set to `nil`, meaning the route from the `Waypoint`will not be influenced by a layer of road.
+     By default, this property is set to `nil`, meaning the route from the `Waypoint` will not be influenced by a layer of road.
      */
     public var layer: Int?
     

--- a/Sources/MapboxDirections/Waypoint.swift
+++ b/Sources/MapboxDirections/Waypoint.swift
@@ -19,6 +19,7 @@ public class Waypoint: Codable, ForeignMemberContainerClass {
         case name
         case allowsArrivingOnOppositeSide
         case snappedDistance = "distance"
+        case layer
     }
     
     // MARK: Creating a Waypoint
@@ -53,6 +54,8 @@ public class Waypoint: Codable, ForeignMemberContainerClass {
         
         snappedDistance = try container.decodeIfPresent(LocationDistance.self, forKey: .snappedDistance)
         
+        layer = try container.decodeIfPresent(Int.self, forKey: .layer)
+        
         try decodeForeignMembers(notKeyedBy: CodingKeys.self, with: decoder)
     }
     
@@ -69,6 +72,7 @@ public class Waypoint: Codable, ForeignMemberContainerClass {
         try container.encodeIfPresent(allowsArrivingOnOppositeSide, forKey: .allowsArrivingOnOppositeSide)
         try container.encodeIfPresent(name, forKey: .name)
         try container.encodeIfPresent(snappedDistance, forKey: .snappedDistance)
+        try container.encodeIfPresent(layer, forKey: .layer)
         
         try encodeForeignMembers(to: encoder)
     }
@@ -175,6 +179,16 @@ public class Waypoint: Codable, ForeignMemberContainerClass {
      By default, this property is set to `nil`, meaning the waypoint has no snapped distance.
      */
     public var snappedDistance: LocationDistance?
+    
+    /**
+     The layer of road that he waypoint is positioned which is used to filter the road segment that the waypoint will be placed on in Z-order. It is useful for avoiding ambiguity in the case of multi-level roads (such as a tunnel under a road).
+     
+     This property corresponds to the ['layers'](https://docs.mapbox.com/api/navigation/directions/#optional-parameters) query parameter in the Mapbox Directions API. If a matching layer is not found, the Mapbox Directions API will choose a suitable layer according to the other procided parameters.
+     
+     // TODO: verify if this is the case
+     By default, this property is set to `nil`, meaning the waypoint is placed on the surface road level.
+     */
+    public var layer: Int?
     
     // MARK: Getting the Direction of Approach
     

--- a/Sources/MapboxDirections/Waypoint.swift
+++ b/Sources/MapboxDirections/Waypoint.swift
@@ -181,12 +181,11 @@ public class Waypoint: Codable, ForeignMemberContainerClass {
     public var snappedDistance: LocationDistance?
     
     /**
-     The layer of road that he waypoint is positioned which is used to filter the road segment that the waypoint will be placed on in Z-order. It is useful for avoiding ambiguity in the case of multi-level roads (such as a tunnel under a road).
+     The layer of road that the waypoint is positioned which is used to filter the road segment that the waypoint will be placed on in Z-order. It is useful for avoiding ambiguity in the case of multi-level roads (such as a tunnel under a road).
      
      This property corresponds to the ['layers'](https://docs.mapbox.com/api/navigation/directions/#optional-parameters) query parameter in the Mapbox Directions API. If a matching layer is not found, the Mapbox Directions API will choose a suitable layer according to the other procided parameters.
      
-     // TODO: verify if this is the case
-     By default, this property is set to `nil`, meaning the waypoint is placed on the surface road level.
+     By default, this property is set to `nil`, meaning the route from the `Waypoint`will not be influenced by a layer of road.
      */
     public var layer: Int?
     

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -22,6 +22,8 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertEqual(unarchivedWaypoints[1].coordinate.longitude, coordinates[1].longitude)
         XCTAssertEqual(unarchivedWaypoints[2].coordinate.latitude, coordinates[2].latitude)
         XCTAssertEqual(unarchivedWaypoints[2].coordinate.longitude, coordinates[2].longitude)
+        XCTAssertEqual(unarchivedWaypoints[0].layer, -1)
+        XCTAssertEqual(unarchivedWaypoints[2].layer, 3)
         
         XCTAssertEqual(unarchivedOptions.profileIdentifier, options.profileIdentifier)
         XCTAssertEqual(unarchivedOptions.locale, options.locale)
@@ -306,6 +308,16 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertTrue(options.urlQueryItems.contains(URLQueryItem(name: "waypoint_targets", value: ";-84.51619,39.13115")))
     }
     
+    func testWaypointLayers(){
+        let from = Waypoint(coordinate: LocationCoordinate2D(latitude: 0, longitude: 0))
+        let through = Waypoint(coordinate: LocationCoordinate2D(latitude: 0, longitude: 0))
+        let to = Waypoint(coordinate: LocationCoordinate2D(latitude: 0, longitude: 0))
+        from.layer = -1
+        to.layer = 3
+        let options = RouteOptions(waypoints: [from, through, to])
+        XCTAssertTrue(options.urlQueryItems.contains(URLQueryItem(name: "layers", value: "-1;;3")))
+    }
+    
     func testInitialManeuverAvoidanceRadiusSerialization() {
         let options = RouteOptions(coordinates: testCoordinates)
         
@@ -362,7 +374,11 @@ fileprivate let testCoordinates = [
 ]
 
 var testRouteOptions: RouteOptions {
-    let opts = RouteOptions(coordinates: testCoordinates, profileIdentifier: .automobileAvoidingTraffic)
+    let waypoints = testCoordinates.map { Waypoint(coordinate: $0)}
+    waypoints[0].layer = -1
+    waypoints[2].layer = 3
+    
+    let opts = RouteOptions(waypoints: waypoints, profileIdentifier: .automobileAvoidingTraffic)
     opts.locale = Locale(identifier: "en_US")
     opts.allowsUTurnAtWaypoint = true
     opts.shapeFormat = .polyline

--- a/Tests/MapboxDirectionsTests/WaypointTests.swift
+++ b/Tests/MapboxDirectionsTests/WaypointTests.swift
@@ -25,6 +25,7 @@ class WaypointTests: XCTestCase {
             XCTAssertTrue(waypoint.allowsArrivingOnOppositeSide)
             XCTAssertTrue(waypoint.separatesLegs)
             XCTAssertEqual(waypoint.snappedDistance, 7.0)
+            XCTAssertNil(waypoint.layer)
         }
         
         waypoint = Waypoint(coordinate: LocationCoordinate2D(latitude: 38.8977, longitude: -77.0365), coordinateAccuracy: 5, name: "White House")
@@ -33,6 +34,7 @@ class WaypointTests: XCTestCase {
         waypoint?.headingAccuracy = 10
         waypoint?.allowsArrivingOnOppositeSide = false
         waypoint?.snappedDistance = 7
+        waypoint?.layer = -1
         
         let encoder = JSONEncoder()
         var encodedData: Data?
@@ -55,6 +57,8 @@ class WaypointTests: XCTestCase {
             encodedWaypointJSON?.removeValue(forKey: "heading")
             XCTAssertEqual(encodedWaypointJSON?["separatesLegs"] as? Bool, waypoint?.separatesLegs)
             encodedWaypointJSON?.removeValue(forKey: "separatesLegs")
+            XCTAssertEqual(encodedWaypointJSON?["layer"] as? Int, waypoint?.layer)
+            encodedWaypointJSON?.removeValue(forKey: "layer")
            
             let targetCoordinateJSON = encodedWaypointJSON?["targetCoordinate"] as? [LocationDegrees]
             XCTAssertNotNil(targetCoordinateJSON)


### PR DESCRIPTION
Added optional interger-typed layer property to `Waypoint` class corresponding to the [layers](https://docs.mapbox.com/api/navigation/directions/#retrieve-directions) URL query parameter.