### PR TITLE
Exposing toll fees

### DIFF
--- a/Sources/MapboxDirections/Route.swift
+++ b/Sources/MapboxDirections/Route.swift
@@ -7,6 +7,9 @@ import Turf
  Typically, you do not create instances of this class directly. Instead, you receive route objects when you request directions using the `Directions.calculate(_:completionHandler:)` or `Directions.calculateRoutes(matching:completionHandler:)` method. However, if you use the `Directions.url(forCalculating:)` method instead, you can use `JSONDecoder` to convert the HTTP response into a `RouteResponse` or `MapMatchingResponse` object and access the `RouteResponse.routes` or `MapMatchingResponse.routes` property.
  */
 open class Route: DirectionsResult {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case tollCosts = "toll_costs"
+    }
     
     /**
      Initializes a route.
@@ -28,8 +31,27 @@ open class Route: DirectionsResult {
      - parameter decoder: The decoder of JSON-formatted API response data or a previously encoded `Route` object.
      */
     public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        tollCosts = try container.decodeIfPresent([TollCost].self, forKey: .tollCosts)
+        
         try super.init(from: decoder)
+        try decodeForeignMembers(notKeyedBy: CodingKeys.self, with: decoder)
     }
+    
+    public override func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(tollCosts, forKey: .tollCosts)
+        
+        try super.encode(to: encoder)
+    }
+    
+    /**
+     :nodoc:
+     List of calculated toll costs for this route.
+     
+     See `TollCost`.
+     */
+    open var tollCosts: [TollCost]?
 }
 
 extension Route: Equatable {

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -107,6 +107,9 @@ open class RouteOptions: DirectionsOptions {
            let arriveBy = formatter.date(from: mappedValue) {
             self.arriveBy = arriveBy
         }
+        if mappedQueryItems[CodingKeys.computeTollCost.stringValue] == "true" {
+            self.computeTollCost = true
+        }
     }
 
     #if canImport(CoreLocation)
@@ -155,6 +158,7 @@ open class RouteOptions: DirectionsOptions {
         case arriveBy = "arrive_by"
         case departAt = "depart_at"
         case layers = "layers"
+        case computeTollCost = "compute_toll_cost"
     }
     
     public override func encode(to encoder: Encoder) throws {
@@ -180,6 +184,10 @@ open class RouteOptions: DirectionsOptions {
         }
         if let departAt = departAt {
             try container.encode(formatter.string(from: departAt), forKey: .departAt)
+        }
+        
+        if computeTollCost {
+            try container.encode(computeTollCost, forKey: .computeTollCost)
         }
     }
     
@@ -224,6 +232,8 @@ open class RouteOptions: DirectionsOptions {
         if let dateString = try container.decodeIfPresent(String.self, forKey: .arriveBy) {
             arriveBy = formatter.date(from: dateString)
         }
+        
+        computeTollCost = try container.decodeIfPresent(Bool.self, forKey: .computeTollCost) ?? false
         
         try super.init(from: decoder)
     }
@@ -393,6 +403,14 @@ open class RouteOptions: DirectionsOptions {
     }
     private var _initialManeuverAvoidanceRadius: LocationDistance?
     
+    /**
+     :nodoc:
+     Toggle whether to return calculated toll cost for the route, if data is available.
+     
+     Default value is `false`.
+     */
+    open var computeTollCost = false
+    
     // MARK: Getting the Request URL
     
     override open var urlQueryItems: [URLQueryItem] {
@@ -472,6 +490,11 @@ open class RouteOptions: DirectionsOptions {
                 params.append(URLQueryItem(name: CodingKeys.arriveBy.stringValue,
                                            value: String(formatter.string(from: arriveBy))))
             }
+        }
+        
+        if computeTollCost {
+            params.append(URLQueryItem(name: CodingKeys.computeTollCost.stringValue,
+                                       value: String(computeTollCost)))
         }
         
         return params + super.urlQueryItems

--- a/Sources/MapboxDirections/TollCost.swift
+++ b/Sources/MapboxDirections/TollCost.swift
@@ -1,0 +1,190 @@
+import Foundation
+import Turf
+
+/**
+ :nodoc:
+ Toll cost information for the `Route`.
+ */
+public struct TollCost: Equatable,  Codable, ForeignMemberContainer {
+    public var foreignMembers: Turf.JSONObject = [:]
+    
+    private enum CodingKeys: String, CodingKey {
+        case currency
+        case paymentMethods = "payment_methods"
+    }
+
+    /**
+     Related currency string.
+     
+     Uses ISO 4217 format. Refers to values in `CostPerVehicleSize`.
+     */
+    public let currency: String
+    /**
+     Information about toll payment methods.
+     */
+    public let paymentMethods: PaymentMethods
+    
+    init(currency: String, paymentMethods: PaymentMethods) {
+        self.currency = currency
+        self.paymentMethods = paymentMethods
+    }
+        
+    /**
+     :nodoc:
+     Information about toll payment methods.
+     */
+    public struct PaymentMethods: Equatable, Codable, ForeignMemberContainer {
+        public var foreignMembers: Turf.JSONObject = [:]
+        
+        private enum CodingKeys: String, CodingKey {
+            case ETC = "etc"
+            case cash
+        }
+        
+        /**
+         Information about payment by ETC.
+         */
+        public let ETC: CostPerVehicleSize?
+        /**
+         Information about payment by cash.
+         */
+        public let cash: CostPerVehicleSize?
+        
+        init(ETC: CostPerVehicleSize? = nil, cash: CostPerVehicleSize? = nil) {
+            self.ETC = ETC
+            self.cash = cash
+        }
+    }
+    
+    /**
+     :nodoc:
+     `PaymentMethods` details about particular vehicle size.
+     
+     Vehicle sizes are [standartized](https://en.wikipedia.org/wiki/Expressways_of_Japan#Tolls).
+     */
+    public struct CostPerVehicleSize: Equatable, Codable, ForeignMemberContainer {
+        public var foreignMembers: Turf.JSONObject = [:]
+        
+        private enum CodingKeys: String, CodingKey {
+            case small
+            case standard
+            case middle
+            case large
+            case jumbo
+        }
+        
+        /**
+         The toll cost for a small sized vehicle.
+         
+         A toll cost of `0` is valid and simply means that no toll costs are incurred for this route.
+         */
+        public let small: Double?
+        /**
+         The toll cost for a standard sized vehicle.
+         
+         A toll cost of `0` is valid and simply means that no toll costs are incurred for this route.
+         */
+        public let standard: Double?
+        /**
+         The toll cost for a middle sized vehicle.
+         
+         A toll cost of `0` is valid and simply means that no toll costs are incurred for this route.
+         */
+        public let middle: Double?
+        /**
+         The toll cost for a large sized vehicle.
+         
+         A toll cost of `0` is valid and simply means that no toll costs are incurred for this route.
+         */
+        public let large: Double?
+        /**
+         The toll cost for a jumbo sized vehicle.
+         
+         A toll cost of `0` is valid and simply means that no toll costs are incurred for this route.
+         */
+        public let jumbo: Double?
+        
+        init(small: Double? = nil,
+             standard: Double? = nil,
+             middle: Double? = nil,
+             large: Double? = nil,
+             jumbo: Double? = nil) {
+            self.small = small
+            self.standard = standard
+            self.middle = middle
+            self.large = large
+            self.jumbo = jumbo
+        }
+    }
+}
+
+
+extension TollCost {
+    public static func == (lhs: TollCost, rhs: TollCost) -> Bool {
+        return lhs.currency == rhs.currency &&
+               lhs.paymentMethods == rhs.paymentMethods
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        currency = try container.decode(String.self, forKey: .currency)
+        paymentMethods = try container.decode(PaymentMethods.self, forKey: .paymentMethods)
+        
+        try decodeForeignMembers(notKeyedBy: CodingKeys.self, with: decoder)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(currency, forKey: .currency)
+        try container.encode(paymentMethods, forKey: .paymentMethods)
+        
+        try encodeForeignMembers(notKeyedBy: CodingKeys.self, to: encoder)
+    }
+}
+
+extension TollCost.PaymentMethods {
+    public static func == (lhs: TollCost.PaymentMethods, rhs: TollCost.PaymentMethods) -> Bool {
+        return lhs.ETC == rhs.ETC &&
+               lhs.cash == rhs.cash
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        ETC = try container.decodeIfPresent(TollCost.CostPerVehicleSize.self, forKey: .ETC)
+        cash = try container.decodeIfPresent(TollCost.CostPerVehicleSize.self, forKey: .cash)
+        
+        try decodeForeignMembers(notKeyedBy: CodingKeys.self, with: decoder)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(ETC, forKey: .ETC)
+        try container.encodeIfPresent(cash, forKey: .cash)
+        
+        try encodeForeignMembers(notKeyedBy: CodingKeys.self, to: encoder)
+    }
+}
+
+extension TollCost.CostPerVehicleSize {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        small = try container.decodeIfPresent(Double.self, forKey: .small)
+        standard = try container.decodeIfPresent(Double.self, forKey: .standard)
+        middle = try container.decodeIfPresent(Double.self, forKey: .middle)
+        large = try container.decodeIfPresent(Double.self, forKey: .large)
+        jumbo = try container.decodeIfPresent(Double.self, forKey: .jumbo)
+        
+        try decodeForeignMembers(notKeyedBy: CodingKeys.self, with: decoder)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(small, forKey: .small)
+        try container.encodeIfPresent(standard, forKey: .standard)
+        try container.encodeIfPresent(middle, forKey: .middle)
+        try container.encodeIfPresent(large, forKey: .large)
+        try container.encodeIfPresent(jumbo, forKey: .jumbo)
+        
+        try encodeForeignMembers(notKeyedBy: CodingKeys.self, to: encoder)
+    }
+}

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -38,6 +38,7 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertEqual(unarchivedOptions.alleyPriority, options.alleyPriority)
         XCTAssertEqual(unarchivedOptions.walkwayPriority, options.walkwayPriority)
         XCTAssertEqual(unarchivedOptions.speed, options.speed)
+        XCTAssertEqual(unarchivedOptions.computeTollCost, options.computeTollCost)
     }
     
     func testCodingWithRawCodingKeys() {
@@ -69,6 +70,7 @@ class RouteOptionsTests: XCTestCase {
             "max_height": 3,
             "alley_bias": DirectionsPriority.low.rawValue,
             "walkway_bias": DirectionsPriority.high.rawValue,
+            "compute_toll_cost": true
         ]
         
         let routeOptionsData = try! JSONSerialization.data(withJSONObject: routeOptionsJSON, options: [])
@@ -94,6 +96,7 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertEqual(routeOptions.maximumWidth, Measurement(value: 2.3, unit: .meters))
         XCTAssertEqual(routeOptions.maximumHeight, Measurement(value: 3, unit: .meters))
         XCTAssertEqual(routeOptions.maximumWeight, Measurement(value: 3.5, unit: .metricTons))
+        XCTAssertEqual(routeOptions.computeTollCost, true)
         
         let encodedRouteOptions: Data = try! JSONEncoder().encode(routeOptions)
         let optionsString: String = String(data: encodedRouteOptions, encoding: .utf8)!
@@ -119,6 +122,7 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertEqual(unarchivedOptions.initialManeuverAvoidanceRadius, routeOptions.initialManeuverAvoidanceRadius)
         XCTAssertEqual(unarchivedOptions.maximumWidth, routeOptions.maximumWidth)
         XCTAssertEqual(unarchivedOptions.maximumHeight, routeOptions.maximumHeight)
+        XCTAssertEqual(unarchivedOptions.computeTollCost, routeOptions.computeTollCost)
     }
     
     func testURLCoding() throws {
@@ -190,6 +194,7 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertEqual(decodedOptions.alleyPriority, originalOptions.alleyPriority)
         XCTAssertEqual(decodedOptions.walkwayPriority, originalOptions.walkwayPriority)
         XCTAssertEqual(decodedOptions.speed, originalOptions.speed)
+        XCTAssertEqual(decodedOptions.computeTollCost, originalOptions.computeTollCost)
         XCTAssertNil(decodedOptions.arriveBy)
         // URL encoding skips seconds, so we check that dates are within 1 minute delta
         XCTAssertTrue(abs(decodedOptions.departAt!.timeIntervalSince(originalOptions.departAt!)) < 60)
@@ -398,6 +403,7 @@ var testRouteOptions: RouteOptions {
     opts.speed = 1
     opts.departAt = Date(timeIntervalSince1970: 500)
     opts.arriveBy = Date(timeIntervalSince1970: 600)
+    opts.computeTollCost = true
 
     return opts
 }

--- a/Tests/MapboxDirectionsTests/RouteTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteTests.swift
@@ -22,6 +22,20 @@ class RouteTests: XCTestCase {
             "duration": 1083.4,
             "duration_typical": 1483.262,
             "distance": 17036.8,
+            "toll_costs": [
+               [
+                    "currency": "JPY",
+                    "payment_methods": [
+                        "etc": [
+                            "standard": 1200,
+                            "middle": 1400
+                        ],
+                        "cash": [
+                            "standard": 1250
+                        ]
+                    ]
+               ],
+            ]
         ]
         let routeData = try! JSONSerialization.data(withJSONObject: routeJSON, options: [])
         
@@ -40,8 +54,13 @@ class RouteTests: XCTestCase {
         let expectedLeg = RouteLeg(steps: [], name: "West 6th Avenue Freeway, South University Boulevard", distance: 17036.8, expectedTravelTime: 1083.4, typicalTravelTime: 1483.262, profileIdentifier: .automobileAvoidingTraffic)
         expectedLeg.source = options.waypoints[0]
         expectedLeg.destination = options.waypoints[1]
+        let expectedTollCosts = TollCost(currency: "JPY",
+                                         paymentMethods: .init(ETC: .init(standard: 1200,
+                                                                          middle: 1400),
+                                                               cash: .init(standard: 1250)))
         let expectedRoute = Route(legs: [expectedLeg], shape: nil, distance: 17036.8, expectedTravelTime: 1083.4, typicalTravelTime: 1483.262)
         XCTAssertEqual(route, expectedRoute)
+        XCTAssertEqual(route?.tollCosts, [expectedTollCosts])
         
         if let route = route {
             let encoder = JSONEncoder()


### PR DESCRIPTION
The PR adds `Route.tollCosts` and `RouteOptions.computeTollCost` for requesting and working with toll fees. Marking new properties and types with `:nodoc:` and skipping CHANGELOG update since it is a private API feature.