### PR TITLE
NAVIOS-663: Adjust incidents indices after refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Other Changes
 
 * Added the `Waypoint.layer` property, which can ensure that the route begins on the correct road if it is above or below another road. ([#745](https://github.com/mapbox/mapbox-directions-swift/pull/745))
+* Fixed incorrect shape indicies in `RouteLeg.incidents` after route refresh. ([#752](https://github.com/mapbox/mapbox-directions-swift/pull/752))
 
 ## 2.7.0
 

--- a/Sources/MapboxDirections/RouteLeg.swift
+++ b/Sources/MapboxDirections/RouteLeg.swift
@@ -289,23 +289,15 @@ open class RouteLeg: Codable, ForeignMemberContainerClass {
     }
     
     func refreshIncidents(newIncidents: [Incident]?, startLegShapeIndex: Int = 0) {
-        guard let newIncidents = newIncidents else {
-            incidents = nil
-            return
+        incidents = newIncidents?.map { incident in
+            var adjustedIncident = incident
+            let startIndex = startLegShapeIndex + incident.shapeIndexRange.lowerBound
+            let endIndex = startLegShapeIndex + incident.shapeIndexRange.upperBound
+            adjustedIncident.shapeIndexRange = startIndex..<endIndex
+            return adjustedIncident
         }
-        
-        incidents?.removeAll(where: {
-            $0.shapeIndexRange.upperBound > startLegShapeIndex
-        })
-        
-        if incidents == nil {
-            incidents = []
-        }
-        
-        incidents?.append(contentsOf: newIncidents)
     }
-    
-    
+
     /**
      Returns the ISO 3166-1 alpha-2 region code for the administrative region through which the given intersection passes. The intersection is identified by its step index and intersection index.
      

--- a/Sources/MapboxDirections/RouteRefreshResponse.swift
+++ b/Sources/MapboxDirections/RouteRefreshResponse.swift
@@ -140,15 +140,21 @@ extension Route {
 
     /**
      Merges the incidents of the given route’s legs into the receiver’s legs.
-     
+
      - parameter refreshedRoute: The route containing leg incidents to merge into the receiver. If this route contains fewer legs than the receiver, this method skips legs from the beginning of the route to make up the difference, so that merging the incidents from a one-leg route affects only the last leg of the receiver.
      - parameter legIndex: The index of a leg, from which to start applying the refreshed incidents.
      - parameter legShapeIndex: Index of a geometry of the `legIndex` leg, where to start refreshing from.
      */
     public func refreshLegIncidents(from refreshedRoute: RouteRefreshSource, legIndex: Int, legShapeIndex: Int) {
-        for (leg, refreshedLeg) in zip(legs[legIndex..<legIndex + refreshedRoute.refreshedLegs.count].enumerated(), refreshedRoute.refreshedLegs) {
-            let startIndex = leg.offset == 0 ? legShapeIndex : 0
-            leg.element.refreshIncidents(newIncidents: refreshedLeg.refreshedIncidents, startLegShapeIndex: startIndex)
+        let endRefreshIndex = legIndex + refreshedRoute.refreshedLegs.count
+        for (index, leg) in legs.enumerated() {
+            if (legIndex..<endRefreshIndex).contains(index) {
+                let refreshedLeg = refreshedRoute.refreshedLegs[index-legIndex]
+                let startIndex = index == legIndex ? legShapeIndex : 0
+                leg.refreshIncidents(newIncidents: refreshedLeg.refreshedIncidents, startLegShapeIndex: startIndex)
+            } else {
+                leg.incidents = nil
+            }
         }
     }
 }


### PR DESCRIPTION
Incidents in the legs of the refreshed route come with shape ranges relative to the "current leg shape index". This is happening only for the first refreshed legs.

This PR also removes stale incidents that aren't in the refresh range (in parity with Android per https://github.com/mapbox/mapbox-navigation-ios/pull/4111#discussion_r986571149).