### PR TITLE
RouteLeg.closures integration

### DIFF
--- a/Sources/MapboxDirections/AttributeOptions.swift
+++ b/Sources/MapboxDirections/AttributeOptions.swift
@@ -19,6 +19,15 @@ public struct AttributeOptions: CustomValueOptionSet, CustomStringConvertible {
     }
     
     /**
+      Live-traffic closures along the road segment.
+      
+      When this attribute is specified, the `RouteLeg.closures` property is filled with relevant data.
+      
+      This attribute requires `ProfileIdentifier.automobileAvoidingTraffic`.
+     */
+    public static let closures = AttributeOptions(rawValue: 1)
+    
+    /**
      Distance (in meters) along the segment.
      
      When this attribute is specified, the `RouteLeg.segmentDistances` property contains one value for each segment in the leg’s full geometry.
@@ -71,6 +80,8 @@ public struct AttributeOptions: CustomValueOptionSet, CustomStringConvertible {
         var attributeOptions: AttributeOptions = []
         for description in descriptions {
             switch description {
+            case "closure":
+                attributeOptions.update(with: .closures)
             case "distance":
                 attributeOptions.update(with: .distance)
             case "duration":
@@ -94,6 +105,9 @@ public struct AttributeOptions: CustomValueOptionSet, CustomStringConvertible {
     
     public var description: String {
         var descriptions: [String] = []
+        if contains(.closures) {
+            descriptions.append("closure")
+        }
         if contains(.distance) {
             descriptions.append("distance")
         }

--- a/Sources/MapboxDirections/Directions.swift
+++ b/Sources/MapboxDirections/Directions.swift
@@ -112,7 +112,7 @@ open class Directions: NSObject {
      - parameter credentials: An object containing the credentials used to make the request.
      - parameter result: A `Result` enum that represents the `RouteRefreshResponse` if the request returned successfully, or the error if it did not.
      
-     - postcondition: To update the original route, pass `RouteRefreshResponse.route` into the `Route.refreshLegAttributes(from:)` and `Route.refreshLegIncidents(from:)` methods.
+     - postcondition: To update the original route, pass `RouteRefreshResponse.route` into the `Route.refreshLegAttributes(from:)`, `Route.refreshLegIncidents(from:)`, `Route.refreshLegClosures(from:legIndex:legShapeIndex:)` or `Route.refresh(from:refreshParameters:)` methods.
      */
     public typealias RouteRefreshCompletionHandler = (_ credentials: Credentials, _ result: Result<RouteRefreshResponse, DirectionsError>) -> Void
     

--- a/Sources/MapboxDirections/RefreshedRoute.swift
+++ b/Sources/MapboxDirections/RefreshedRoute.swift
@@ -41,18 +41,21 @@ public struct RefreshedRouteLeg: ForeignMemberContainer {
     
     public var attributes: RouteLeg.Attributes
     public var incidents: [Incident]?
+    public var closures: [RouteLeg.Closure]?
 }
 
 extension RefreshedRouteLeg: Codable {
     enum CodingKeys: String, CodingKey {
         case attributes = "annotation"
         case incidents = "incidents"
+        case closures = "closures"
     }
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         attributes = try container.decode(RouteLeg.Attributes.self, forKey: .attributes)
         incidents = try container.decodeIfPresent([Incident].self, forKey: .incidents)
+        closures = try container.decodeIfPresent([RouteLeg.Closure].self, forKey: .closures)
         
         try decodeForeignMembers(notKeyedBy: CodingKeys.self, with: decoder)
     }
@@ -61,6 +64,7 @@ extension RefreshedRouteLeg: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(attributes, forKey: .attributes)
         try container.encodeIfPresent(incidents, forKey: .incidents)
+        try container.encodeIfPresent(closures, forKey: .closures)
         
         try encodeForeignMembers(notKeyedBy: CodingKeys.self, to: encoder)
     }

--- a/Sources/MapboxDirections/RouteRefreshSource.swift
+++ b/Sources/MapboxDirections/RouteRefreshSource.swift
@@ -13,10 +13,14 @@ public protocol RouteRefreshSource {
 public protocol RouteLegRefreshSource {
     var refreshedAttributes: RouteLeg.Attributes { get }
     var refreshedIncidents: [Incident]? { get }
+    var refreshedClosures: [RouteLeg.Closure]? { get }
 }
 
 public extension RouteLegRefreshSource {
     var refreshedIncidents: [Incident]? {
+        return nil
+    }
+    var refreshedClosures: [RouteLeg.Closure]? {
         return nil
     }
 }
@@ -35,6 +39,10 @@ extension RouteLeg: RouteLegRefreshSource {
     public var refreshedIncidents: [Incident]? {
         incidents
     }
+    
+    public var refreshedClosures: [RouteLeg.Closure]? {
+        closures
+    }
 }
 
 extension RefreshedRoute: RouteRefreshSource {
@@ -50,5 +58,9 @@ extension RefreshedRouteLeg: RouteLegRefreshSource {
     
     public var refreshedIncidents: [Incident]? {
         incidents
+    }
+    
+    public var refreshedClosures: [RouteLeg.Closure]? {
+        closures
     }
 }

--- a/Tests/MapboxDirectionsTests/Fixtures/RouteRefresh/partialRouteRefreshResponse.json
+++ b/Tests/MapboxDirectionsTests/Fixtures/RouteRefresh/partialRouteRefreshResponse.json
@@ -3,6 +3,12 @@
     "route": {
         "legs": [
             {
+                "closures": [
+                    {
+                        "geometry_index_start": 16,
+                        "geometry_index_end": 20,
+                    }
+                ],
                 "incidents": [
                     {
                         "id": "12727074056824787215",
@@ -337,6 +343,12 @@
                 }
             },
             {
+                "closures": [
+                    {
+                        "geometry_index_start": 9,
+                        "geometry_index_end": 14,
+                    }
+                ],
                 "incidents": [
                     {
                         "id": "12779545487967908590",

--- a/Tests/MapboxDirectionsTests/Fixtures/RouteRefresh/routeRefreshResponse.json
+++ b/Tests/MapboxDirectionsTests/Fixtures/RouteRefresh/routeRefreshResponse.json
@@ -3,6 +3,12 @@
     "route": {
         "legs": [
             {
+                "closures": [
+                    {
+                        "geometry_index_start": 8,
+                        "geometry_index_end": 20,
+                    }
+                ],
                 "incidents": [
                     {
                         "id": "12727074056824787215",
@@ -382,6 +388,12 @@
                 }
             },
             {
+                "closures": [
+                    {
+                        "geometry_index_start": 6,
+                        "geometry_index_end": 18,
+                    }
+                ],
                 "incidents": [
                     {
                         "id": "12779545487967908590",


### PR DESCRIPTION
This PR adds support for RouteLeg Closures. Added corresponding type, properties in RouteLeg and DirectionsOptions. Also updated refreshing methods for the new updated info. Refreshing also refined a bit by introducing single refresh method with flexible configuration which should cover possible variations and reduce amount of user code for refreshing routes.