### PR TITLE
Update to Turf `v2.6.0-beta.1`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Packaging
 
 * This library now requires a minimum deployment target of iOS 12.0 or above, macOS 10.14.0 or above, tvOS 12.0 or above, or watchOS 5.0 or above. Older operating system versions are no longer supported. ([#736](https://github.com/mapbox/mapbox-directions-swift/pull/736))
+* MapboxDirections now requires [Turf v2.6.0-beta.1](https://github.com/mapbox/turf-swift/releases/tag/v2.6.0-beta.1). ([#757](https://github.com/mapbox/mapbox-directions-swift/pull/757))
 
 ### Other Changes
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "raphaelmor/Polyline" ~> 5.0
-github "mapbox/turf-swift" ~> 2.4
+github "mapbox/turf-swift" "v2.6.0-beta.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "9.1.0"
 github "mapbox/mapbox-events-ios" "v0.10.14"
-github "mapbox/turf-swift" "v2.5.0"
+github "mapbox/turf-swift" "v2.6.0-beta.1"
 github "raphaelmor/Polyline" "v5.1.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "dbc07b0a298d642414d3abec59c9eaba1fb3367f",
-          "version": "2.5.0"
+          "revision": "2a6db53ca1ba358d77795e9e359ca589f78147a1",
+          "version": "2.6.0-beta.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/raphaelmor/Polyline.git", from: "5.0.2"),
-        .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.4.0"),
+        .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", .exact("2.6.0-beta.1")),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs", from: "9.1.0")
     ],


### PR DESCRIPTION
Xcode 14 is unable to lint Mapbox Directions when running:
```
$ pod spec lint MapboxDirections-pre.podspec --verbose
```
because of incorrect deployment target in `Turf`.

Update to Turf `v2.6.0-beta.1` aims to resolve this issue.

Cocoapods linting with Xcode 13.2.1 works fine.