### PR TITLE
Change minimum versions of dependencies for `v2.6.1`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to Mapbox Directions for Swift
 
+## v2.6.1
+
+### Packaging
+
+* This release of MapboxDirections requires Turf v2.5._x_ to work around a dependency resolution failure. If you use Carthage, it requires Turf v2.5.0 exactly. ([#771](https://github.com/mapbox/mapbox-directions-swift/pull/771))
+
 ## v2.6.0
 
 * MapboxDirections now requires [Turf v2.4](https://github.com/mapbox/turf-swift/releases/tag/v2.4.0). ([#703](https://github.com/mapbox/mapbox-directions-swift/pull/703))

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "raphaelmor/Polyline" ~> 5.0
-github "mapbox/turf-swift" ~> 2.4
+github "mapbox/turf-swift" == 2.5.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "9.1.0"
 github "mapbox/mapbox-events-ios" "v0.10.14"
-github "mapbox/turf-swift" "v2.4.0"
-github "raphaelmor/Polyline" "v5.0.3"
+github "mapbox/turf-swift" "v2.5.0"
+github "raphaelmor/Polyline" "v5.1.0"

--- a/MapboxDirections.podspec
+++ b/MapboxDirections.podspec
@@ -46,6 +46,6 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
 
   s.dependency "Polyline", "~> 5.0"
-  s.dependency "Turf", "~> 2.4"
+  s.dependency "Turf", "~> 2.5.0"
 
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/raphaelmor/Polyline.git",
         "state": {
           "branch": null,
-          "revision": "554a15b15ff33cf6757f4cb693c5c285fe58694e",
-          "version": "5.0.3"
+          "revision": "353f80378dcd8f17eefe8550090c6b1ae3c9da23",
+          "version": "5.1.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "f3c9084a71ef4376f2fabbdf1d3d90a49f1fabdb",
-          "version": "1.1.2"
+          "revision": "fddd1c00396eed152c45a46bea9f47b98e59301d",
+          "version": "1.2.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "569e0f0e96fda86e1a1dcefaefa68cfa9491ffc1",
-          "version": "2.4.0"
+          "revision": "dbc07b0a298d642414d3abec59c9eaba1fb3367f",
+          "version": "2.5.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/raphaelmor/Polyline.git", from: "5.0.2"),
-        .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", from: "2.4.0"),
+        .package(name: "Turf", url: "https://github.com/mapbox/turf-swift.git", .upToNextMinor(from: "2.5.0")),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs", from: "9.1.0")
     ],


### PR DESCRIPTION
Change minimum versions of dependencies for the Mapbox Directions `v2.6.1`.