### PR TITLE
Excluding cash tolls roads fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `Matrix` API wrapper. The [Mapbox Matrix API](https://docs.mapbox.com/api/navigation/matrix/) computes travel times between many points, and returns a matrix of all travel times between the locations. [#626](https://github.com/mapbox/mapbox-directions-swift/pull/626)
 * Fixed a crash that could occur if only one `Waypoint` with a nonnull `name` was used in the Directions request. [#797](https://github.com/mapbox/mapbox-directions-swift/pull/797)
 * Added `Interchange` and `Junction` structs describing IC and JCT. [#799](https://github.com/mapbox/mapbox-directions-swift/pull/799)
+* Fixed an issue where using `cashTollOnly` for road class exclusions failed the directions request. ([#801](https://github.com/mapbox/mapbox-directions-swift/pull/801))
 
 ## v2.9.0
 

--- a/Sources/MapboxDirections/RoadClasses.swift
+++ b/Sources/MapboxDirections/RoadClasses.swift
@@ -121,7 +121,7 @@ public struct RoadClasses: OptionSet, CustomStringConvertible {
                 roadClasses.insert(.highOccupancyToll)
             case "unpaved":
                 roadClasses.insert(.unpaved)
-            case "cash_only_toll":
+            case "cash_only_tolls":
                 roadClasses.insert(.cashTollOnly)
             case "":
                 continue
@@ -162,7 +162,7 @@ public struct RoadClasses: OptionSet, CustomStringConvertible {
             descriptions.append("unpaved")
         }
         if contains(.cashTollOnly) {
-            descriptions.append("cash_only_toll")
+            descriptions.append("cash_only_tolls")
         }
         return descriptions.joined(separator: ",")
     }

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -357,7 +357,7 @@ class RouteOptionsTests: XCTestCase {
         options.roadClassesToAvoid = [.toll, .motorway, .ferry, .unpaved, .cashTollOnly]
         options.roadClassesToAllow = [.highOccupancyVehicle2, .highOccupancyVehicle3, .highOccupancyToll]
 
-        let expectedExcludeQueryItem = URLQueryItem(name: "exclude", value: "toll,motorway,ferry,unpaved,cash_only_toll")
+        let expectedExcludeQueryItem = URLQueryItem(name: "exclude", value: "toll,motorway,ferry,unpaved,cash_only_tolls")
         XCTAssertTrue(options.urlQueryItems.contains(expectedExcludeQueryItem))
 
         let expectedIncludeQueryItem = URLQueryItem(name: "include", value: "hov2,hov3,hot")


### PR DESCRIPTION
Resolves #779 
This PR corrects `cashTollOnly` string value mistype.