### PR TITLE
Update Xcode version for publish-documentation job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ jobs:
 
   publish-documentation:
     macos:
-      xcode: "12.5.1"
+      xcode: "14.1.0"
     steps:
       - checkout
       - install-mapbox-token


### PR DESCRIPTION
Fixes the failing `Publish Documentation` job caused by the old Xcode version:

```
Checkouts/turf-swift/Sources/Turf/GeoJSON.swift:11:39: error: cannot find type 'Sendable' in scope
public enum GeoJSONObject: Equatable, Sendable {
                                      ^~~~~~~~
```