### PR TITLE
Make encode methods public for open model classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to Mapbox Directions for Swift
 
+## v2.14.2
+
+* The `encode(to:)` methods in `DirectionsOptions`, `MatchOptions`, `RouteOptions`, and others open classes are now declared as open instead of public. ([#837](https://github.com/mapbox/mapbox-directions-swift/pull/837))
+
 ## v2.14.1
 
 * Fixed `ProfileIdentifier` comparison for the custom profile identifiers. ([#833](https://github.com/mapbox/mapbox-directions-swift/pull/833))

--- a/Sources/MapboxDirections/DirectionsOptions.swift
+++ b/Sources/MapboxDirections/DirectionsOptions.swift
@@ -279,7 +279,7 @@ open class DirectionsOptions: Codable {
         case includesVisualInstructions = "banner_instructions"
     }
     
-    public func encode(to encoder: Encoder) throws {
+    open func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(waypoints, forKey: .waypoints)
         try container.encode(profileIdentifier, forKey: .profileIdentifier)

--- a/Sources/MapboxDirections/DirectionsResult.swift
+++ b/Sources/MapboxDirections/DirectionsResult.swift
@@ -71,7 +71,7 @@ open class DirectionsResult: Codable, ForeignMemberContainerClass {
     }
     
     
-    public func encode(to encoder: Encoder) throws {
+    open func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(legs, forKey: .legs)
         if let shape = shape {

--- a/Sources/MapboxDirections/MapMatching/Match.swift
+++ b/Sources/MapboxDirections/MapMatching/Match.swift
@@ -85,7 +85,7 @@ open class Match: DirectionsResult {
         try decodeForeignMembers(notKeyedBy: CodingKeys.self, with: decoder)
     }
     
-    public override func encode(to encoder: Encoder) throws {
+    open override func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(confidence, forKey: .confidence)
         try container.encode(weight.value, forKey: .weight)

--- a/Sources/MapboxDirections/MapMatching/MatchOptions.swift
+++ b/Sources/MapboxDirections/MapMatching/MatchOptions.swift
@@ -75,7 +75,7 @@ open class MatchOptions: DirectionsOptions {
         case resamplesTraces = "tidy"
     }
     
-    public override func encode(to encoder: Encoder) throws {
+    open override func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(resamplesTraces, forKey: .resamplesTraces)
         try super.encode(to: encoder)

--- a/Sources/MapboxDirections/Route.swift
+++ b/Sources/MapboxDirections/Route.swift
@@ -38,7 +38,7 @@ open class Route: DirectionsResult {
         try decodeForeignMembers(notKeyedBy: CodingKeys.self, with: decoder)
     }
     
-    public override func encode(to encoder: Encoder) throws {
+    open override func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(tollPrices.map { TollPriceCoder(tollPrices: $0) }, forKey: .tollPrices)
         

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -163,7 +163,7 @@ open class RouteOptions: DirectionsOptions {
         case includesTollPrices = "compute_toll_cost"
     }
     
-    public override func encode(to encoder: Encoder) throws {
+    open override func encode(to encoder: Encoder) throws {
         try super.encode(to: encoder)
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(allowsUTurnAtWaypoint, forKey: .allowsUTurnAtWaypoint)

--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -552,7 +552,7 @@ open class RouteStep: Codable, ForeignMemberContainerClass {
         self.segmentIndicesByIntersection = segmentIndicesByIntersection
     }
     
-    public func encode(to encoder: Encoder) throws {
+    open func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(instructionsSpokenAlongStep, forKey: .instructionsSpokenAlongStep)
         try container.encodeIfPresent(instructionsDisplayedAlongStep, forKey: .instructionsDisplayedAlongStep)

--- a/Sources/MapboxDirections/VisualInstruction.swift
+++ b/Sources/MapboxDirections/VisualInstruction.swift
@@ -28,7 +28,7 @@ open class VisualInstruction: Codable, ForeignMemberContainerClass {
         self.finalHeading = degrees
     }
     
-    public func encode(to encoder: Encoder) throws {
+    open func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(text, forKey: .text)
         try container.encodeIfPresent(maneuverType, forKey: .maneuverType)

--- a/Sources/MapboxDirections/VisualInstructionBanner.swift
+++ b/Sources/MapboxDirections/VisualInstructionBanner.swift
@@ -34,7 +34,7 @@ open class VisualInstructionBanner: Codable, ForeignMemberContainerClass {
         self.drivingSide = drivingSide
     }
     
-    public func encode(to encoder: Encoder) throws {
+    open func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(distanceAlongStep, forKey: .distanceAlongStep)
         try container.encode(primaryInstruction, forKey: .primaryInstruction)


### PR DESCRIPTION
Fixes [NAVIOS-2273](https://mapbox.atlassian.net/browse/NAVIOS-2273)

Supports the ability to overwrite the encoding for open classes.

[NAVIOS-2273]: https://mapbox.atlassian.net/browse/NAVIOS-2273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ