### PR TITLE
Support Directions API point exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes to Mapbox Directions for Swift
 
+## Unreleased
+
+* Added `RouteOptions.excludedLocations` allowing you to exclude custom locations (such as dangerous entry/exit points, low quality roads, etc.) from routing by coordinate, in addition to the existing road-class-based `RouteOptions.roadClassesToAvoid`. This experimental feature maps to the Directions API's beta `exclude=point(longitude latitude)` parameter and is currently limited to the `mapbox/driving` and `mapbox/driving-traffic` profiles, with at most 50 locations per request.
+* Fixed `RouteOptions.roadClassesToAvoid`/`roadClassesToAllow` parsing (from a URL or from an archived/persisted `RouteOptions`) so that a single unrecognized road-class value no longer discards every other recognized value alongside it, and no longer fails decoding the entire `RouteOptions` object. Surrounding whitespace is now ignored as well, so an `exclude` or `include` parameter written the way the Directions API documents it (`toll, motorway`) is recognized in full.
+
 ## v2.14.4
 
 * Added detection of duplicated URL request parameters derived from `DirectionsOptions`, `IsochroneOptions`, and `MatrixOptions` - an error is logged when duplicates are found.

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -45,6 +45,9 @@
 		2B46024728EDB1670008A624 /* CustomValueOptionSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46024428EDB1670008A624 /* CustomValueOptionSet.swift */; };
 		2B46024828EDB1670008A624 /* CustomValueOptionSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46024428EDB1670008A624 /* CustomValueOptionSet.swift */; };
 		2B46025328EDB62E0008A624 /* AttributeOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46024A28EDB18B0008A624 /* AttributeOptionsTests.swift */; };
+		2CD0A1012E992AF6008706B8 /* RoadClassesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD0A1002E992AF6008706B8 /* RoadClassesTests.swift */; };
+		2CD0A1022E992AF6008706B8 /* RoadClassesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD0A1002E992AF6008706B8 /* RoadClassesTests.swift */; };
+		2CD0A1032E992AF6008706B8 /* RoadClassesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD0A1002E992AF6008706B8 /* RoadClassesTests.swift */; };
 		2B46025428EDB62F0008A624 /* AttributeOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46024A28EDB18B0008A624 /* AttributeOptionsTests.swift */; };
 		2B46025528EDB6300008A624 /* AttributeOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46024A28EDB18B0008A624 /* AttributeOptionsTests.swift */; };
 		2B46025628EDB6390008A624 /* CustomStringOptionSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46024928EDB18B0008A624 /* CustomStringOptionSetTests.swift */; };
@@ -595,6 +598,7 @@
 		2B46024428EDB1670008A624 /* CustomValueOptionSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomValueOptionSet.swift; sourceTree = "<group>"; };
 		2B46024928EDB18B0008A624 /* CustomStringOptionSetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomStringOptionSetTests.swift; sourceTree = "<group>"; };
 		2B46024A28EDB18B0008A624 /* AttributeOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributeOptionsTests.swift; sourceTree = "<group>"; };
+		2CD0A1002E992AF6008706B8 /* RoadClassesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoadClassesTests.swift; sourceTree = "<group>"; };
 		2B46DB0B27EDF8580068C893 /* RouteRefreshResponseWithForeignMembers.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = RouteRefreshResponseWithForeignMembers.json; sourceTree = "<group>"; };
 		2B5407EC2451B17E006C820B /* RouteRefreshResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteRefreshResponse.swift; sourceTree = "<group>"; };
 		2B5407F12452FA8C006C820B /* RefreshedRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshedRoute.swift; sourceTree = "<group>"; };
@@ -1039,6 +1043,7 @@
 				C59666382048A20E00C45CE5 /* RoutableMatchTests.swift */,
 				DAE2DF6B23AED2280065057A /* RouteTests.swift */,
 				DA8F3A7123B56D3B00B56786 /* RouteLegTests.swift */,
+				2CD0A1002E992AF6008706B8 /* RoadClassesTests.swift */,
 				DAE9E0F31EB7DE2E001E8E8B /* RouteOptionsTests.swift */,
 				4376A52623FB13D400C6038D /* MatchOptionsTests.swift */,
 				2B0BA068294B546300402F81 /* MatrixTests.swift */,
@@ -1687,6 +1692,7 @@
 				DA1A10CD1D00F972009F82FA /* V5Tests.swift in Sources */,
 				DAE33A1C1F215DF600C06039 /* IntersectionTests.swift in Sources */,
 				2B46025428EDB62F0008A624 /* AttributeOptionsTests.swift in Sources */,
+				2CD0A1012E992AF6008706B8 /* RoadClassesTests.swift in Sources */,
 				2B5407FD245B070A006C820B /* RouteRefreshTests.swift in Sources */,
 				C5DAACB0201AA92B001F9261 /* MatchTests.swift in Sources */,
 				DA1A10CE1D00F972009F82FA /* Fixture.swift in Sources */,
@@ -1806,6 +1812,7 @@
 				DA1A10F41D010251009F82FA /* V5Tests.swift in Sources */,
 				DAE33A1D1F215DF600C06039 /* IntersectionTests.swift in Sources */,
 				2B46025528EDB6300008A624 /* AttributeOptionsTests.swift in Sources */,
+				2CD0A1022E992AF6008706B8 /* RoadClassesTests.swift in Sources */,
 				2B5407FE245B070A006C820B /* RouteRefreshTests.swift in Sources */,
 				C5DAACB1201AA92B001F9261 /* MatchTests.swift in Sources */,
 				DA1A10F51D010251009F82FA /* Fixture.swift in Sources */,
@@ -1999,6 +2006,7 @@
 				DAE33A1B1F215DF600C06039 /* IntersectionTests.swift in Sources */,
 				2C64731B2E994478008C0D11 /* CustomMatrixOptions.swift in Sources */,
 				2B46025328EDB62E0008A624 /* AttributeOptionsTests.swift in Sources */,
+				2CD0A1032E992AF6008706B8 /* RoadClassesTests.swift in Sources */,
 				2B5407FC245B070A006C820B /* RouteRefreshTests.swift in Sources */,
 				8A47418F2947D1E100F231F9 /* AmenityTests.swift in Sources */,
 				C5DAACAF201AA92B001F9261 /* MatchTests.swift in Sources */,

--- a/Sources/MapboxDirections/Extensions/CoreLocation.swift
+++ b/Sources/MapboxDirections/Extensions/CoreLocation.swift
@@ -33,6 +33,40 @@ public typealias LocationAccuracy = Double
 
 extension LocationCoordinate2D {
     internal var requestDescription: String {
-        return "\(longitude.rounded(to: 1e6)),\(latitude.rounded(to: 1e6))"
+        return "\(longitude.roundedForWKT),\(latitude.roundedForWKT)"
+    }
+    
+    /**
+     The coordinate formatted as a WKT `point(longitude latitude)` literal, as expected by the Directions API’s `exclude` parameter for excluding custom locations from routing.
+     */
+    internal var wktPointDescription: String {
+        return "point(\(longitude.roundedForWKT) \(latitude.roundedForWKT))"
+    }
+    
+    /**
+     Creates a coordinate from a WKT `point(longitude latitude)` literal, as produced by `wktPointDescription`.
+     
+     Surrounding whitespace is ignored. Returns `nil` if the string isn’t a well-formed WKT point.
+     */
+    internal init?<S>(wktPointDescription: S) where S: StringProtocol {
+        let literal = wktPointDescription.trimmingCharacters(in: .whitespaces)
+        let keyword = "point("
+        guard literal.prefix(keyword.count).lowercased() == keyword, literal.hasSuffix(")") else {
+            return nil
+        }
+        let inner = literal.dropFirst(keyword.count).dropLast()
+        let components = inner.split(separator: " ")
+        guard components.count == 2,
+              let longitude = LocationDegrees(components[0]),
+              let latitude = LocationDegrees(components[1]) else {
+            return nil
+        }
+        self.init(latitude: latitude, longitude: longitude)
+    }
+}
+
+extension Double {
+    fileprivate var roundedForWKT: Double {
+        return rounded(to: 1e6)
     }
 }

--- a/Sources/MapboxDirections/RoadClasses.swift
+++ b/Sources/MapboxDirections/RoadClasses.swift
@@ -97,12 +97,14 @@ public struct RoadClasses: OptionSet, CustomStringConvertible {
     public static let cashTollOnly = RoadClasses(rawValue: 1 << 10)
     
     /**
-     Creates a `RoadClasses` given an array of strings.
+     Creates a `RoadClasses` given an array of description strings.
+     
+     Unknown description strings are dropped silently and any surrounding whitespace is ignored.
      */
-    public init?(descriptions: [String]) {
+    public init(from descriptions: [String]) {
         var roadClasses: RoadClasses = []
         for description in descriptions {
-            switch description {
+            switch description.trimmingCharacters(in: .whitespaces) {
             case "toll":
                 roadClasses.insert(.toll)
             case "restricted":
@@ -126,10 +128,23 @@ public struct RoadClasses: OptionSet, CustomStringConvertible {
             case "":
                 continue
             default:
-                return nil
+                continue
             }
         }
         self.init(rawValue: roadClasses.rawValue)
+    }
+    
+    /**
+     Creates a `RoadClasses` given an array of strings.
+     */
+    @available(*, deprecated, message: "Use the more gracious `init(from:)` instead.")
+    public init?(descriptions: [String]) {
+        let graciousRoadClasses = RoadClasses(from: descriptions)
+        if descriptions.count == graciousRoadClasses.descriptionTokens.count {
+            self = graciousRoadClasses
+        } else {
+            return nil
+        }
     }
     
     public var description: String {
@@ -166,22 +181,24 @@ public struct RoadClasses: OptionSet, CustomStringConvertible {
         }
         return descriptions.joined(separator: ",")
     }
+    
+    /**
+     The individual `exclude`/`include` description tokens that make up this value, as opposed to `description`, which joins them with commas for direct use in a query string.
+     */
+    internal var descriptionTokens: [String] {
+        return description.components(separatedBy: ",").filter { !$0.isEmpty }
+    }
 }
 
 extension RoadClasses: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(description.components(separatedBy: ",").filter { !$0.isEmpty })
+        try container.encode(descriptionTokens)
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let descriptions = try container.decode([String].self)
-        if let roadClasses = RoadClasses(descriptions: descriptions){
-            self = roadClasses
-        }
-        else{
-            throw DirectionsError.invalidResponse(nil)
-        }
+        self.init(from: descriptions)
     }
 }

--- a/Sources/MapboxDirections/RouteOptions.swift
+++ b/Sources/MapboxDirections/RouteOptions.swift
@@ -55,13 +55,13 @@ open class RouteOptions: DirectionsOptions {
            let speed = LocationSpeed(mappedValue) {
             self.speed = speed
         }
-        if let mappedValue = mappedQueryItems[CodingKeys.roadClassesToAvoid.stringValue],
-           let roadClassesToAvoid = RoadClasses(descriptions:mappedValue.components(separatedBy: ",")) {
-            self.roadClassesToAvoid = roadClassesToAvoid
+        if let mappedValue = mappedQueryItems[CodingKeys.elementsToExclude.stringValue] {
+            let excludeComponents = mappedValue.components(separatedBy: ",")
+            self.excludedLocations = excludeComponents.compactMap(LocationCoordinate2D.init(wktPointDescription:))
+            self.roadClassesToAvoid = RoadClasses(from: excludeComponents)
         }
-        if let mappedValue = mappedQueryItems[CodingKeys.roadClassesToAllow.stringValue],
-           let roadClassesToAllow = RoadClasses(descriptions:mappedValue.components(separatedBy: ",")) {
-            self.roadClassesToAllow = roadClassesToAllow
+        if let mappedValue = mappedQueryItems[CodingKeys.roadClassesToAllow.stringValue] {
+            self.roadClassesToAllow = RoadClasses(from: mappedValue.components(separatedBy: ","))
         }
         if mappedQueryItems[CodingKeys.refreshingEnabled.stringValue] == "true"
             && profileIdentifier?.isAutomobileAvoidingTraffic ?? false {
@@ -146,7 +146,7 @@ open class RouteOptions: DirectionsOptions {
         case allowsUTurnAtWaypoint = "continue_straight"
         case includesAlternativeRoutes = "alternatives"
         case includesExitRoundaboutManeuver = "roundabout_exits"
-        case roadClassesToAvoid = "exclude"
+        case elementsToExclude = "exclude"
         case roadClassesToAllow = "include"
         case refreshingEnabled = "enable_refresh"
         case initialManeuverAvoidanceRadius = "avoid_maneuver_radius"
@@ -169,7 +169,9 @@ open class RouteOptions: DirectionsOptions {
         try container.encode(allowsUTurnAtWaypoint, forKey: .allowsUTurnAtWaypoint)
         try container.encode(includesAlternativeRoutes, forKey: .includesAlternativeRoutes)
         try container.encode(includesExitRoundaboutManeuver, forKey: .includesExitRoundaboutManeuver)
-        try container.encode(roadClassesToAvoid, forKey: .roadClassesToAvoid)
+        // Matching the API concept of sharing the `exclude` key for `roadClassesToAvoid` and `excludedLocations`
+        try container.encode(roadClassesToAvoid.descriptionTokens + excludedLocations.map { $0.wktPointDescription },
+                             forKey: .elementsToExclude)
         try container.encode(roadClassesToAllow, forKey: .roadClassesToAllow)
         try container.encode(refreshingEnabled, forKey: .refreshingEnabled)
         try container.encodeIfPresent(initialManeuverAvoidanceRadius, forKey: .initialManeuverAvoidanceRadius)
@@ -201,9 +203,11 @@ open class RouteOptions: DirectionsOptions {
 
         includesExitRoundaboutManeuver = try container.decode(Bool.self, forKey: .includesExitRoundaboutManeuver)
     
-        roadClassesToAvoid = try container.decode(RoadClasses.self, forKey: .roadClassesToAvoid)
+        let excludeTokens = (try? container.decode([String].self, forKey: .elementsToExclude)) ?? []
+        excludedLocations = excludeTokens.compactMap(LocationCoordinate2D.init(wktPointDescription:))
+        roadClassesToAvoid = RoadClasses(from: excludeTokens)
         
-        roadClassesToAllow = try container.decode(RoadClasses.self, forKey: .roadClassesToAllow)
+        roadClassesToAllow = RoadClasses(from: (try? container.decode([String].self, forKey: .roadClassesToAllow)) ?? [])
         
         refreshingEnabled = try container.decode(Bool.self, forKey: .refreshingEnabled)
         
@@ -276,7 +280,7 @@ open class RouteOptions: DirectionsOptions {
     /**
      The route classes that the calculated routes will avoid.
      
-     Currently, you can only specify a single road class to avoid.
+     Exclusions are best-effort. When an excluded road type cannot be avoided (for example, it is the only way to reach a waypoint), the route may still use it. These cases are reported by `RouteResponse.roadClassExclusionViolations`, which you can check to detect when an exclusion was not honored.
      */
     open var roadClassesToAvoid: RoadClasses = []
     
@@ -286,6 +290,19 @@ open class RouteOptions: DirectionsOptions {
      This property has no effect unless the profile identifier is set to `ProfileIdentifier.automobile` or `ProfileIdentifier.automobileAvoidingTraffic`.
     */
     open var roadClassesToAllow: RoadClasses = []
+    
+    /**
+     Custom locations that the calculated routes will avoid.
+     
+     Each location is snapped to the nearest road, and that road segment is excluded from routing. This is useful for avoiding dangerous entry/exit points, bridges, tunnels, low quality roads, and cross-border roads that aren’t otherwise captured by `roadClassesToAvoid`.
+     
+     Exclusions are best-effort: if a location can’t be avoided (for example, it’s the only way to reach a waypoint), the route may still pass through it. You can specify at most 50 locations.
+     
+     This property has no effect unless the profile identifier is set to `ProfileIdentifier.automobile` or `ProfileIdentifier.automobileAvoidingTraffic`.
+     
+     - note: This is a beta feature of the Directions API and is subject to change.
+     */
+    open var excludedLocations: [LocationCoordinate2D] = []
     
     /**
      The number that influences whether the route should prefer or avoid alleys or narrow service roads between buildings.
@@ -437,9 +454,10 @@ open class RouteOptions: DirectionsOptions {
             params.append(URLQueryItem(name: CodingKeys.speed.stringValue, value: String(speed)))
         }
 
-        if !roadClassesToAvoid.isEmpty {
-            let roadClasses = roadClassesToAvoid.description
-            params.append(URLQueryItem(name: CodingKeys.roadClassesToAvoid.stringValue, value: roadClasses))
+        let excludedLocationsString = excludedLocations.map { $0.wktPointDescription }.joined(separator: ",")
+        let excludeValue = [roadClassesToAvoid.description, excludedLocationsString].filter { !$0.isEmpty }.joined(separator: ",")
+        if !excludeValue.isEmpty {
+            params.append(URLQueryItem(name: CodingKeys.elementsToExclude.stringValue, value: excludeValue))
         }
         
         if !roadClassesToAllow.isEmpty {

--- a/Tests/MapboxDirectionsTests/RoadClassesTests.swift
+++ b/Tests/MapboxDirectionsTests/RoadClassesTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import MapboxDirections
+
+class RoadClassesTests: XCTestCase {
+    @available(*, deprecated, message: "To be removed with RoadClasses(descriptions:)")
+    func testInitFromDescriptionsFailsOnUnrecognizedToken() {
+        // This strictness is the previously documented public API; `init(from:)` exists for the tolerant case.
+        XCTAssertNil(RoadClasses(descriptions: ["toll", "some_future_api_value"]))
+        XCTAssertEqual(RoadClasses(descriptions: ["toll", "motorway"]), [.toll, .motorway])
+    }
+    
+    func testInitKeepsRecognizedTokensAndIgnoresUnrecognizedOnes() {
+        let roadClasses = RoadClasses(from: ["toll", "some_future_api_value", "motorway"])
+        XCTAssertEqual(roadClasses, [.toll, .motorway])
+    }
+    
+    func testInitWithAllUnrecognizedTokensReturnsEmpty() {
+        XCTAssertEqual(RoadClasses(from: ["some_future_api_value", "another_one"]), [])
+    }
+    
+    @available(*, deprecated, message: "To be removed with RoadClasses(descriptions:)")
+    func testInitWithAllRecognizedTokensMatchesStrictInit() {
+        let descriptions = ["toll", "motorway", "ferry"]
+        XCTAssertEqual(RoadClasses(from: descriptions), RoadClasses(descriptions: descriptions))
+    }
+    
+    func testInitIgnoresSurroundingWhitespace() {
+        XCTAssertEqual(RoadClasses(from: ["toll", " motorway", " "]), [.toll, .motorway])
+    }
+}

--- a/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -468,6 +468,209 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertTrue(options.urlQueryItems.contains(expectedIncludeQueryItem))
     }
 
+    func testUnrecognizedRoadClassInQueryItemsKeepsRecognizedOnes() {
+        let queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "exclude", value: "toll,some_future_api_value,motorway"),
+            URLQueryItem(name: "include", value: "hov2,some_future_api_value"),
+        ]
+        let waypoints = [
+            Waypoint(coordinate: LocationCoordinate2D(latitude: 0, longitude: 0)),
+            Waypoint(coordinate: LocationCoordinate2D(latitude: 1, longitude: 1)),
+        ]
+
+        let options = RouteOptions(waypoints: waypoints, profileIdentifier: .automobile, queryItems: queryItems)
+
+        XCTAssertEqual(options.roadClassesToAvoid, [.toll, .motorway])
+        XCTAssertEqual(options.roadClassesToAllow, [.highOccupancyVehicle2])
+    }
+
+    private static var baseRouteOptionsJSON: [String: Any?] {
+        return [
+            "waypoints": [
+                ["location": [-77.036500000000004, 38.8977], "name": "White House"],
+            ],
+            "profile": "mapbox/driving-traffic",
+            "steps": true,
+            "geometries": "polyline",
+            "overview": "simplified",
+            "annotations": ["congestion"],
+            "language": "en_US",
+            "voice_instructions": true,
+            "voice_units": "imperial",
+            "banner_instructions": true,
+            "continue_straight": true,
+            "alternatives": false,
+            "roundabout_exits": true,
+            "enable_refresh": false,
+            "avoid_maneuver_radius": 300,
+            "max_width": 2.3,
+            "max_weight": 3.5,
+            "max_height": 3,
+            "alley_bias": DirectionsPriority.low.rawValue,
+            "walkway_bias": DirectionsPriority.high.rawValue,
+            "compute_toll_cost": true,
+        ]
+    }
+
+    func testUnrecognizedRoadClassInJSONDoesNotFailWholeDecode() throws {
+        var routeOptionsJSON = Self.baseRouteOptionsJSON
+        routeOptionsJSON["exclude"] = ["toll", "some_future_api_value"]
+        routeOptionsJSON["include"] = ["some_future_api_value"]
+        let routeOptionsData = try JSONSerialization.data(withJSONObject: routeOptionsJSON, options: [])
+
+        let routeOptions = try JSONDecoder().decode(RouteOptions.self, from: routeOptionsData)
+
+        XCTAssertEqual(routeOptions.profileIdentifier, .automobileAvoidingTraffic)
+        XCTAssertEqual(routeOptions.roadClassesToAvoid, .toll)
+        XCTAssertEqual(routeOptions.roadClassesToAllow, [])
+    }
+
+    func testMissingRoadClassKeysInJSONDefaultToEmpty() throws {
+        var routeOptionsJSON = Self.baseRouteOptionsJSON
+        routeOptionsJSON["exclude"] = nil
+        routeOptionsJSON["include"] = nil
+        let routeOptionsData = try JSONSerialization.data(withJSONObject: routeOptionsJSON, options: [])
+
+        let routeOptions = try JSONDecoder().decode(RouteOptions.self, from: routeOptionsData)
+
+        XCTAssertEqual(routeOptions.roadClassesToAvoid, [])
+        XCTAssertEqual(routeOptions.roadClassesToAllow, [])
+    }
+
+    func testExcludedLocationsURLQueryParam() {
+        let options = RouteOptions(coordinates: testCoordinates)
+        options.excludedLocations = [
+            LocationCoordinate2D(latitude: 38.897, longitude: -77.036),
+            LocationCoordinate2D(latitude: 40.7128, longitude: -74.006),
+        ]
+
+        let expectedExcludeQueryItem = URLQueryItem(name: "exclude", value: "point(-77.036 38.897),point(-74.006 40.7128)")
+        XCTAssertTrue(options.urlQueryItems.contains(expectedExcludeQueryItem))
+    }
+
+    func testExcludedLocationsCombinedWithRoadClassesToAvoid() {
+        let options = RouteOptions(coordinates: testCoordinates)
+        options.roadClassesToAvoid = [.toll, .motorway]
+        options.excludedLocations = [LocationCoordinate2D(latitude: 38.897, longitude: -77.036)]
+
+        let expectedExcludeQueryItem = URLQueryItem(name: "exclude", value: "toll,motorway,point(-77.036 38.897)")
+        XCTAssertTrue(options.urlQueryItems.contains(expectedExcludeQueryItem))
+    }
+
+    func testExcludedLocationsOmittedFromURLWhenEmpty() {
+        let options = RouteOptions(coordinates: testCoordinates)
+        XCTAssertFalse(options.urlQueryItems.map { $0.name }.contains("exclude"))
+    }
+
+    func testExcludedLocationsInitializationFromQueryItems() {
+        let queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "exclude", value: "toll,point(-77.036 38.897),motorway,point(-74.006 40.7128)"),
+        ]
+
+        let waypoints = [
+            Waypoint(coordinate: LocationCoordinate2D(latitude: 0, longitude: 0)),
+            Waypoint(coordinate: LocationCoordinate2D(latitude: 1, longitude: 1)),
+        ]
+        let options = RouteOptions(waypoints: waypoints, profileIdentifier: .automobile, queryItems: queryItems)
+
+        XCTAssertEqual(options.roadClassesToAvoid, [.toll, .motorway])
+        XCTAssertEqual(options.excludedLocations.count, 2)
+        XCTAssertEqual(options.excludedLocations[0].latitude, 38.897, accuracy: 1e-6)
+        XCTAssertEqual(options.excludedLocations[0].longitude, -77.036, accuracy: 1e-6)
+        XCTAssertEqual(options.excludedLocations[1].latitude, 40.7128, accuracy: 1e-6)
+        XCTAssertEqual(options.excludedLocations[1].longitude, -74.006, accuracy: 1e-6)
+    }
+
+    func testExcludedLocationsInitializationFromSpaceSeparatedQueryItems() {
+        // The API documents this parameter with a space after each comma, so a URL written to match the
+        // documentation has to parse too.
+        let queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "exclude", value: "toll, motorway, point(-77.036 38.897), point(-74.006 40.7128)"),
+        ]
+
+        let waypoints = [
+            Waypoint(coordinate: LocationCoordinate2D(latitude: 0, longitude: 0)),
+            Waypoint(coordinate: LocationCoordinate2D(latitude: 1, longitude: 1)),
+        ]
+        let options = RouteOptions(waypoints: waypoints, profileIdentifier: .automobile, queryItems: queryItems)
+
+        XCTAssertEqual(options.roadClassesToAvoid, [.toll, .motorway])
+        XCTAssertEqual(options.excludedLocations.count, 2)
+        XCTAssertEqual(options.excludedLocations[0].latitude, 38.897, accuracy: 1e-6)
+        XCTAssertEqual(options.excludedLocations[0].longitude, -77.036, accuracy: 1e-6)
+        XCTAssertEqual(options.excludedLocations[1].latitude, 40.7128, accuracy: 1e-6)
+        XCTAssertEqual(options.excludedLocations[1].longitude, -74.006, accuracy: 1e-6)
+    }
+
+    func testExcludedLocationsSurviveFullURLRoundTrip() throws {
+        // Guards the percent-encoding of the space inside each `point(lon lat)` literal.
+        let options = RouteOptions(coordinates: testCoordinates, profileIdentifier: .automobile)
+        options.roadClassesToAvoid = [.toll]
+        options.excludedLocations = [LocationCoordinate2D(latitude: 38.897, longitude: -77.036)]
+
+        let url = Directions(credentials: BogusCredentials).url(forCalculating: options)
+        XCTAssertTrue(url.absoluteString.contains("exclude=toll,point(-77.036%2038.897)"),
+                      "Unexpected exclude parameter in \(url.absoluteString)")
+
+        let decoded = try XCTUnwrap(RouteOptions(url: url))
+        XCTAssertEqual(decoded.roadClassesToAvoid, [.toll])
+        XCTAssertEqual(decoded.excludedLocations.count, 1)
+        XCTAssertEqual(decoded.excludedLocations[0].latitude, 38.897, accuracy: 1e-6)
+        XCTAssertEqual(decoded.excludedLocations[0].longitude, -77.036, accuracy: 1e-6)
+    }
+
+    func testExcludedLocationsCoding() throws {
+        let options = RouteOptions(coordinates: testCoordinates)
+        options.excludedLocations = [
+            LocationCoordinate2D(latitude: 38.897, longitude: -77.036),
+            LocationCoordinate2D(latitude: 40.7128, longitude: -74.006),
+        ]
+
+        let encoded = try JSONEncoder().encode(options)
+        let decoded = try JSONDecoder().decode(RouteOptions.self, from: encoded)
+
+        XCTAssertEqual(decoded.excludedLocations.count, options.excludedLocations.count)
+        zip(decoded.excludedLocations, options.excludedLocations).forEach {
+            XCTAssertEqual($0.0.latitude, $0.1.latitude, accuracy: 1e-6)
+            XCTAssertEqual($0.0.longitude, $0.1.longitude, accuracy: 1e-6)
+        }
+
+        let optionsWithoutExclusions = RouteOptions(coordinates: testCoordinates)
+        let encodedWithoutExclusions = try JSONEncoder().encode(optionsWithoutExclusions)
+        let decodedWithoutExclusions = try JSONDecoder().decode(RouteOptions.self, from: encodedWithoutExclusions)
+        XCTAssertEqual(decodedWithoutExclusions.excludedLocations, [])
+    }
+
+    func testRoadClassesAndExcludedLocationsShareTheExcludeJSONKey() throws {
+        let options = RouteOptions(coordinates: testCoordinates)
+        options.roadClassesToAvoid = [.toll, .motorway]
+        options.excludedLocations = [LocationCoordinate2D(latitude: 38.897, longitude: -77.036)]
+
+        let encoded = try JSONEncoder().encode(options)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        XCTAssertEqual(json["exclude"] as? [String], ["toll", "motorway", "point(-77.036 38.897)"])
+        XCTAssertNil(json["exclude_locations"])
+
+        let decoded = try JSONDecoder().decode(RouteOptions.self, from: encoded)
+        XCTAssertEqual(decoded.roadClassesToAvoid, [.toll, .motorway])
+        XCTAssertEqual(decoded.excludedLocations.count, 1)
+        XCTAssertEqual(decoded.excludedLocations[0].latitude, 38.897, accuracy: 1e-6)
+        XCTAssertEqual(decoded.excludedLocations[0].longitude, -77.036, accuracy: 1e-6)
+    }
+
+    func testDecodingMixedExcludeTokensFromRawJSON() throws {
+        var routeOptionsJSON = Self.baseRouteOptionsJSON
+        routeOptionsJSON["exclude"] = ["toll", "point(-77.036 38.897)", "some_future_api_value"]
+        let routeOptionsData = try JSONSerialization.data(withJSONObject: routeOptionsJSON, options: [])
+
+        let routeOptions = try JSONDecoder().decode(RouteOptions.self, from: routeOptionsData)
+
+        XCTAssertEqual(routeOptions.roadClassesToAvoid, .toll)
+        XCTAssertEqual(routeOptions.excludedLocations.count, 1)
+        XCTAssertEqual(routeOptions.excludedLocations[0].latitude, 38.897, accuracy: 1e-6)
+        XCTAssertEqual(routeOptions.excludedLocations[0].longitude, -77.036, accuracy: 1e-6)
+    }
+
     func testReturnPathIfNoWaypointsAndOneWaypoint() {
         let noWaypointOptions = RouteOptions(coordinates: [])
         XCTAssertEqual(noWaypointOptions.path, noWaypointOptions.abridgedPath)


### PR DESCRIPTION
## Support Directions API point exclusions

Adds `RouteOptions.excludedLocations`, mapping to the Directions API's experimental `exclude=point(longitude latitude)` parameter. Locations can now be excluded by coordinate in addition to the existing road-class-based `RouteOptions.roadClassesToAvoid`. Each location is snapped to the nearest road, and that road segment is excluded from routing. 
This is a beta feature of the Directions API, limited to the `mapbox/driving` and `mapbox/driving-traffic` profiles, with at most 50 locations per request.

Also fixes two pre-existing issues in the same parsing path:

* A single unrecognized `exclude`/`include` value discarded every recognized value alongside it and failed the entire `RouteOptions` decode.
* Values written with a space after the comma (`toll, motorway`), as the API documents them, were not parsed.

### API changes

* Added `RouteOptions.excludedLocations`.
* Added `RoadClasses.init(from:)`, which drops unrecognized description strings instead of failing.
* Deprecated `RoadClasses.init?(descriptions:)` in favor of `init(from:)`.

### Compatibility

No breaking API changes, and existing archives decode unchanged. Archives that contain point exclusions will not decode on earlier versions.